### PR TITLE
GeoWeb Nginx ingress controller HTTP to HTTPS redirect

### DIFF
--- a/charts/nginx-ingress-controller/Chart.yaml
+++ b/charts/nginx-ingress-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nginx-ingress-controller/templates/nginx-ingress-configmap.yaml
+++ b/charts/nginx-ingress-controller/templates/nginx-ingress-configmap.yaml
@@ -1,6 +1,12 @@
 apiVersion: v1
 data:
   allow-snippet-annotations: "true"
+  http-snippet: |
+    server {
+      listen 2443;
+      return 308 https://$host$request_uri;
+    }
+  use-forwarded-headers: "true"
 kind: ConfigMap
 metadata:
   name: {{ .Values.ingress.name }}

--- a/charts/nginx-ingress-controller/templates/nginx-ingress-daemonset.yaml
+++ b/charts/nginx-ingress-controller/templates/nginx-ingress-daemonset.yaml
@@ -61,6 +61,9 @@ spec:
         - containerPort: 80
           name: http
           protocol: TCP
+        - name: tohttps
+          containerPort: 2443
+          protocol: TCP
         #- containerPort: 8443
         #  name: webhook
         #  protocol: TCP

--- a/charts/nginx-ingress-controller/templates/nginx-loadbalancer-svc.yaml
+++ b/charts/nginx-ingress-controller/templates/nginx-loadbalancer-svc.yaml
@@ -19,6 +19,10 @@ spec:
     port: 443
     protocol: TCP
     targetPort: 80
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: tohttps
   selector:
     app.kubernetes.io/name: {{ .Values.ingress.name }}
   type: LoadBalancer


### PR DESCRIPTION
* Enables HTTP to HTTPS redirection in GeoWeb frontend.
* The load balancer type is kept as NLB and SSL termination is still done at the load balancer. Doing the SSL termination at load balancer has some advantages which is why this solution was chosen,