### PR TITLE
Add ability to use custom preset files in geoweb-presets-backend

### DIFF
--- a/charts/geoweb-presets-backend/Chart.yaml
+++ b/charts/geoweb-presets-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.1
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-presets-backend/README.md
+++ b/charts/geoweb-presets-backend/README.md
@@ -27,6 +27,27 @@ presets:
   db_secret: base64_encoded_postgresql_connection_string
 ```
 
+* Using custom presets stored locally
+```yaml
+presets:
+  url: geoweb.example.com
+  useCustomWorkspacePresets: true
+  customPresetsFolderPath: /example/path/ # NOTE: Don't include the preset file
+```
+
+* Using custom presets stored in AWS S3
+```yaml
+presets:
+  url: geoweb.example.com
+  useCustomWorkspacePresets: true
+  customWorkspacePresetLocation: s3
+  s3bucketName: example-bucket
+  customPresetsFile: example-path/customPresets.json
+  awsAccessKeyId: <AWS_ACCESS_KEY_ID>
+  awsAccessKeySecret: <AWS_SECRET_ACCESS_KEY>
+  awsDefaultRegion: <AWS_DEFAULT_REGION>
+```
+
 # Testing the Chart
 Execute the following for testing the chart:
 
@@ -83,11 +104,14 @@ The following table lists the configurable parameters of the Presets backend cha
 | `presets.nginx.OAUTH2_USERINFO` | - | `https://gitlab.com/oauth/userinfo` |
 | `presets.nginx.PRESETS_BACKEND_HOST` | Address where nginx accesses the backend | `0.0.0.0:8080` |
 | `presets.nginx.NGINX_PORT_HTTP` | Port used for nginx | `80` |
-| `presets.useCustomWorkspacePresets` | Use PersistentVolume to provide custom presets to the application | `false` |
+| `presets.useCustomWorkspacePresets` | Use custom presets | `false` |
+| `presets.customWorkspacePresetLocation` | Where custom presets are located *(local\|s3)* | `local` |
 | `presets.volumeAccessMode` | Permissions of the application for the custom presets PersistentVolume used | `ReadOnlyMany` |
 | `presets.volumeSize` | Size of the custom presets PersistentVolume | `100Mi` |
-| `presets.volumeType` | Type of the PersistentVolume used, supporting hostPath and [csi-s3](https://github.com/yandex-cloud/k8s-csi-s3) | `hostPath` |
-| `presets.volumePath` | Path which you mount your custom presets from (`bucket-name/path` when using csi-s3) | `/mnt/presets` |
-| `presets.csiNamespace` | Namespace where csi-s3 driver is running | `kube-system` |
-| `presets.csiSecretName` | Secret created by csi-s3 driver | `csi-s3-secret` |
+| `presets.customPresetsFolderPath` | Path to the folder which contains custom presets (used locally) | |
+| `presets.s3bucketName` | Name of the S3 bucket where custom presets are stored | |
+| `presets.customPresetsFile` | ile which contains custom presets including path to it (used with s3) | |
+| `presets.awsAccessKeyId` | AWS_ACCESS_KEY_ID for authenticating to S3 | |
+| `presets.awsAccessKeySecret` | AWS_SECRET_ACCESS_KEY for authenticating to S3 | |
+| `presets.awsDefaultRegion` | Region where your S3 bucket is located | |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |

--- a/charts/geoweb-presets-backend/README.md
+++ b/charts/geoweb-presets-backend/README.md
@@ -83,4 +83,11 @@ The following table lists the configurable parameters of the Presets backend cha
 | `presets.nginx.OAUTH2_USERINFO` | - | `https://gitlab.com/oauth/userinfo` |
 | `presets.nginx.PRESETS_BACKEND_HOST` | Address where nginx accesses the backend | `0.0.0.0:8080` |
 | `presets.nginx.NGINX_PORT_HTTP` | Port used for nginx | `80` |
+| `presets.useCustomWorkspacePresets` | Use PersistentVolume to provide custom presets to the application | `false` |
+| `presets.volumeAccessMode` | Permissions of the application for the custom presets PersistentVolume used | `ReadOnlyMany` |
+| `presets.volumeSize` | Size of the custom presets PersistentVolume | `100Mi` |
+| `presets.volumeType` | Type of the PersistentVolume used, supporting hostPath and [csi-s3](https://github.com/yandex-cloud/k8s-csi-s3) | `hostPath` |
+| `presets.volumePath` | Path which you mount your custom presets from (`bucket-name/path` when using csi-s3) | `/mnt/presets` |
+| `presets.csiNamespace` | Namespace where csi-s3 driver is running | `kube-system` |
+| `presets.csiSecretName` | Secret created by csi-s3 driver | `csi-s3-secret` |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |

--- a/charts/geoweb-presets-backend/README.md
+++ b/charts/geoweb-presets-backend/README.md
@@ -32,7 +32,7 @@ presets:
 presets:
   url: geoweb.example.com
   useCustomWorkspacePresets: true
-  customPresetsFolderPath: /example/path/ # NOTE: Don't include the preset file
+  customPresetsPath: /example/path/
 ```
 
 * Using custom presets stored in AWS S3
@@ -42,7 +42,7 @@ presets:
   useCustomWorkspacePresets: true
   customWorkspacePresetLocation: s3
   s3bucketName: example-bucket
-  customPresetsFile: example-path/customPresets.json
+  customPresetsPath: /example/path/
   awsAccessKeyId: <AWS_ACCESS_KEY_ID>
   awsAccessKeySecret: <AWS_SECRET_ACCESS_KEY>
   awsDefaultRegion: <AWS_DEFAULT_REGION>
@@ -108,9 +108,8 @@ The following table lists the configurable parameters of the Presets backend cha
 | `presets.customWorkspacePresetLocation` | Where custom presets are located *(local\|s3)* | `local` |
 | `presets.volumeAccessMode` | Permissions of the application for the custom presets PersistentVolume used | `ReadOnlyMany` |
 | `presets.volumeSize` | Size of the custom presets PersistentVolume | `100Mi` |
-| `presets.customPresetsFolderPath` | Path to the folder which contains custom presets (used locally) | |
+| `presets.customPresetsPath` | Path to the folder which contains custom presets | |
 | `presets.s3bucketName` | Name of the S3 bucket where custom presets are stored | |
-| `presets.customPresetsFile` | ile which contains custom presets including path to it (used with s3) | |
 | `presets.awsAccessKeyId` | AWS_ACCESS_KEY_ID for authenticating to S3 | |
 | `presets.awsAccessKeySecret` | AWS_SECRET_ACCESS_KEY for authenticating to S3 | |
 | `presets.awsDefaultRegion` | Region where your S3 bucket is located | |

--- a/charts/geoweb-presets-backend/templates/presets-deployment.yaml
+++ b/charts/geoweb-presets-backend/templates/presets-deployment.yaml
@@ -33,7 +33,7 @@ spec:
             export AWS_ACCESS_KEY_ID={{ .Values.presets.awsAccessKeyId }};
             export AWS_SECRET_ACCESS_KEY={{ .Values.presets.awsAccessKeySecret }};
             AWS_DEFAULT_REGION={{ .Values.presets.awsDefaultRegion }};
-            aws s3 cp s3://{{ .Values.presets.s3bucketName }}/{{ .Values.presets.customPresetsFile }} /presets;
+            aws s3 cp --recursive s3://{{ .Values.presets.s3bucketName }}{{ .Values.presets.customPresetsPath }} /presets;
         volumeMounts:
         - mountPath: "/presets/"
           name: {{ .Values.presets.name }}-volume

--- a/charts/geoweb-presets-backend/templates/presets-deployment.yaml
+++ b/charts/geoweb-presets-backend/templates/presets-deployment.yaml
@@ -47,6 +47,10 @@ spec:
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
           readOnly: true
+      {{- if .Values.presets.useCustomWorkspacePresets }}
+        - mountPath: "/app/staticpresets"
+          name: {{ .Values.presets.name }}-pv
+      {{- end }}
       - name: {{ .Values.presets.nginx.name }}
         image: {{ .Values.presets.nginx.registry }}:{{ .Values.versions.presets }}
       {{- if .Values.presets.imagePullPolicy }}
@@ -58,6 +62,11 @@ spec:
         - configMapRef:
             name: {{ .Values.presets.nginx.name }}
       volumes:
+      {{- if .Values.presets.useCustomWorkspacePresets }}
+      - name: {{ .Values.presets.name }}-pv
+        persistentVolumeClaim:
+          claimName: {{ .Values.presets.name }}-pvc
+      {{- end }}
       - name: secrets-store-inline
       {{- if .Values.secretProvider }}
         csi:

--- a/charts/geoweb-presets-backend/templates/presets-deployment.yaml
+++ b/charts/geoweb-presets-backend/templates/presets-deployment.yaml
@@ -22,6 +22,22 @@ spec:
     {{- if eq .Values.secretProvider "aws" }}
       serviceAccountName: {{ .Values.presets.secretServiceAccount }}
     {{- end }}
+    {{- if and .Values.presets.useCustomWorkspacePresets (eq .Values.presets.customWorkspacePresetLocation "s3")}}
+      initContainers:
+      - name: init
+        image: amazon/aws-cli
+        command: ["/bin/sh"]
+        args:
+          - -c
+          - |
+            export AWS_ACCESS_KEY_ID={{ .Values.presets.awsAccessKeyId }};
+            export AWS_SECRET_ACCESS_KEY={{ .Values.presets.awsAccessKeySecret }};
+            AWS_DEFAULT_REGION={{ .Values.presets.awsDefaultRegion }};
+            aws s3 cp s3://{{ .Values.presets.s3bucketName }}/{{ .Values.presets.customPresetsFile }} /presets;
+        volumeMounts:
+        - mountPath: "/presets/"
+          name: {{ .Values.presets.name }}-volume
+    {{- end }}
       containers:
       - name: {{ .Values.presets.name }}
         image: {{ .Values.presets.registry }}:{{ .Values.versions.presets }}
@@ -47,9 +63,9 @@ spec:
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
           readOnly: true
-      {{- if .Values.presets.useCustomWorkspacePresets }}
+      {{- if and .Values.presets.useCustomWorkspacePresets }}
         - mountPath: "/app/staticpresets"
-          name: {{ .Values.presets.name }}-pv
+          name: {{ .Values.presets.name }}-volume
       {{- end }}
       - name: {{ .Values.presets.nginx.name }}
         image: {{ .Values.presets.nginx.registry }}:{{ .Values.versions.presets }}
@@ -62,11 +78,15 @@ spec:
         - configMapRef:
             name: {{ .Values.presets.nginx.name }}
       volumes:
-      {{- if .Values.presets.useCustomWorkspacePresets }}
-      - name: {{ .Values.presets.name }}-pv
+    {{- if .Values.presets.useCustomWorkspacePresets}}
+      - name: {{ .Values.presets.name }}-volume
+      {{- if eq .Values.presets.customWorkspacePresetLocation "s3"}}
+        emptyDir: {}
+      {{- else if eq .Values.presets.customWorkspacePresetLocation "local"}}
         persistentVolumeClaim:
-          claimName: {{ .Values.presets.name }}-pvc
+          claimName: {{ .Values.presets.name }}-claim
       {{- end }}
+    {{- end }}
       - name: secrets-store-inline
       {{- if .Values.secretProvider }}
         csi:

--- a/charts/geoweb-presets-backend/templates/presets-volume.yaml
+++ b/charts/geoweb-presets-backend/templates/presets-volume.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.presets.useCustomWorkspacePresets }}
+{{- if and .Values.presets.useCustomWorkspacePresets (eq .Values.presets.customWorkspacePresetLocation "local")}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.presets.name }}-pvc
+  name: {{ .Values.presets.name }}-claim
 spec:
   storageClassName: ""
   accessModes:
@@ -14,38 +14,16 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ .Values.presets.name }}-pv
+  name: {{ .Values.presets.name }}-volume
 spec:
-{{- if eq .Values.presets.volumeType "hostPath" }}
   storageClassName: manual
-{{- else if eq .Values.presets.volumeType "csi-s3" }}
-  storageClassName: csi-s3
-{{- end }}
   capacity:
     storage: {{ .Values.presets.volumeSize }}
   accessModes:
     - {{ .Values.presets.volumeAccessMode }}
   claimRef:
     namespace: {{ .Release.Namespace }}
-    name: {{ .Values.presets.name }}-pvc
-{{- if eq .Values.presets.volumeType "hostPath" }}
+    name: {{ .Values.presets.name }}-claim
   hostPath:
-    path: {{ .Values.presets.volumePath | quote }}
-{{- else if eq .Values.presets.volumeType "csi-s3" }}
-  csi:
-    driver: ru.yandex.s3.csi
-    controllerPublishSecretRef:
-      name: {{ .Values.presets.csiSecretName }}
-      namespace: {{ .Values.presets.csiNamespace }}
-    nodePublishSecretRef:
-      name: {{ .Values.presets.csiSecretName }}
-      namespace: {{ .Values.presets.csiNamespace }}
-    nodeStageSecretRef:
-      name: {{ .Values.presets.csiSecretName }}
-      namespace: {{ .Values.presets.csiNamespace }}
-    volumeAttributes:
-      capacity: {{ .Values.presets.volumeSize }}
-      mounter: geesefs
-    volumeHandle: {{ .Values.presets.volumePath }}
-{{- end }}
+    path: {{ .Values.presets.customPresetsFolderPath | quote }}
 {{- end }}

--- a/charts/geoweb-presets-backend/templates/presets-volume.yaml
+++ b/charts/geoweb-presets-backend/templates/presets-volume.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.presets.useCustomWorkspacePresets }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.presets.name }}-pvc
+spec:
+  storageClassName: ""
+  accessModes:
+    - {{ .Values.presets.volumeAccessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.presets.volumeSize }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.presets.name }}-pv
+spec:
+{{- if eq .Values.presets.volumeType "hostPath" }}
+  storageClassName: manual
+{{- else if eq .Values.presets.volumeType "csi-s3" }}
+  storageClassName: csi-s3
+{{- end }}
+  capacity:
+    storage: {{ .Values.presets.volumeSize }}
+  accessModes:
+    - {{ .Values.presets.volumeAccessMode }}
+  claimRef:
+    namespace: {{ .Release.Namespace }}
+    name: {{ .Values.presets.name }}-pvc
+{{- if eq .Values.presets.volumeType "hostPath" }}
+  hostPath:
+    path: {{ .Values.presets.volumePath | quote }}
+{{- else if eq .Values.presets.volumeType "csi-s3" }}
+  csi:
+    driver: ru.yandex.s3.csi
+    controllerPublishSecretRef:
+      name: {{ .Values.presets.csiSecretName }}
+      namespace: {{ .Values.presets.csiNamespace }}
+    nodePublishSecretRef:
+      name: {{ .Values.presets.csiSecretName }}
+      namespace: {{ .Values.presets.csiNamespace }}
+    nodeStageSecretRef:
+      name: {{ .Values.presets.csiSecretName }}
+      namespace: {{ .Values.presets.csiNamespace }}
+    volumeAttributes:
+      capacity: {{ .Values.presets.volumeSize }}
+      mounter: geesefs
+    volumeHandle: {{ .Values.presets.volumePath }}
+{{- end }}
+{{- end }}

--- a/charts/geoweb-presets-backend/values.yaml
+++ b/charts/geoweb-presets-backend/values.yaml
@@ -21,12 +21,9 @@ presets:
     PRESETS_BACKEND_HOST: 0.0.0.0:8080
     NGINX_PORT_HTTP: 80
   useCustomWorkspacePresets: false
+  customWorkspacePresetLocation: local
   volumeAccessMode: ReadOnlyMany
   volumeSize: 100Mi
-  volumeType: hostPath
-  volumePath: /mnt/presets
-  csiNamespace: kube-system
-  csiSecretName: csi-s3-secret
 
 ingress:
   name: nginx-ingress-controller # Sync with nginx-ingress-controller/values.yaml

--- a/charts/geoweb-presets-backend/values.yaml
+++ b/charts/geoweb-presets-backend/values.yaml
@@ -20,5 +20,13 @@ presets:
     OAUTH2_USERINFO: https://gitlab.com/oauth/userinfo
     PRESETS_BACKEND_HOST: 0.0.0.0:8080
     NGINX_PORT_HTTP: 80
+  useCustomWorkspacePresets: false
+  volumeAccessMode: ReadOnlyMany
+  volumeSize: 100Mi
+  volumeType: hostPath
+  volumePath: /mnt/presets
+  csiNamespace: kube-system
+  csiSecretName: csi-s3-secret
+
 ingress:
   name: nginx-ingress-controller # Sync with nginx-ingress-controller/values.yaml


### PR DESCRIPTION
Added two options to override default preset files found in presets-backend /app/staticpresets folder:
1. (Default) Create PersistentVolume out of a past in the host machine
2. Use AWS-CLI to fetch presets from S3 bucket

Closes https://gitlab.com/opengeoweb/fmi/fmi-aws-config/-/issues/132