### PR TITLE
Custom configuration options to frontend chart

### DIFF
--- a/charts/geoweb-frontend/Chart.yaml
+++ b/charts/geoweb-frontend/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v4.19.1"
+appVersion: "v5.0.1"

--- a/charts/geoweb-frontend/README.md
+++ b/charts/geoweb-frontend/README.md
@@ -54,6 +54,27 @@ frontend:
 
 ```
 
+* Using custom configuration files stored locally
+```yaml
+frontend:
+  url: geoweb.example.com
+  useCustomConfigurationFiles: true
+  customConfigurationFolderPath: /example/path/
+```
+
+* Using custom configuration files stored in AWS S3
+```yaml
+frontend:
+  url: geoweb.example.com
+  useCustomConfigurationFiles: true
+  customConfigurationLocation: s3
+  s3bucketName: example-bucket
+  customConfigurationFolderPath: /example/path/
+  awsAccessKeyId: <AWS_ACCESS_KEY_ID>
+  awsAccessKeySecret: <AWS_SECRET_ACCESS_KEY>
+  awsDefaultRegion: <AWS_DEFAULT_REGION>
+```
+
 # Testing the Chart
 Execute the following for testing the chart:
 
@@ -84,7 +105,7 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 
 | Parameter | Description | Default |
 | - | - | - |
-| `versions.frontend` | Possibility to override application version | `v4.19.1` |
+| `versions.frontend` | Possibility to override application version | `v5.0.1` |
 | `frontend.name` | Name of frontend | `geoweb` |
 | `frontend.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/opengeoweb` |
 | `frontend.commitHash` | Adds commitHash annotation to the deployment | |
@@ -109,7 +130,6 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 | `secretProviderParameters` | Option to add custom parameters to the secretProvider, for example with aws you can specify region | |
 | `frontend.env.GW_CAP_BASE_URL` | Url which the application uses to connect to CAP backend | |
 | `frontend.env.GW_APP_URL` | Url which the application can be accessed | |
-| `frontend.env.GW_GITLAB_PRESETS_PATH` | Path in repository to fetch screen presets | |
 | `frontend.env.GW_DEFAULT_THEME` | Default theme: lightMode or darkMode | |
 | `frontend.env.GW_FEATURE_APP_TITLE` | Application title | |
 | `frontend.env.GW_PRESET_BACKEND_URL` | Url which the application uses to connect to Presets backend | |
@@ -117,11 +137,9 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 | `frontend.env.GW_AUTH_TOKEN_URL` | - | `https://gitlab.com/oauth/token` |
 | `frontend.env.GW_AUTH_LOGIN_URL` | Url to redirect when logging in | `https://gitlab.com/oauth/authorize?client_id={client_id}&response_type=code&scope=email+openid+read_repository+read_api&redirect_uri={app_url}/code&state={state}&code_challenge={code_challenge}&code_challenge_method=S256` |
 | `frontend.env.GW_INFRA_BASE_URL` | - | `https://api.opengeoweb.com` |
-| `frontend.env.GW_GITLAB_PRESETS_BASE_URL` | Base url to fetch screen presets | `https://gitlab.com/api/v4/projects` |
-| `frontend.env.GW_GITLAB_PRESETS_API_PATH` | Path in gitlab to fetch screen presets | `/{project_id}/repository/files/{presets_path}{preset_filename}/raw?ref={branch}` |
-| `frontend.env.GW_GITLAB_PROJECT_ID` | Project id of gitlab project to fetch screen presets | `"24089222"` |
-| `frontend.env.GW_GITLAB_BRANCH` | Branch to fetch screen presets | `master` |
 | `frontend.env.GW_INITIAL_PRESETS_FILENAME` | Filename to fetch initial presets | `initialPresets.json` |
+| `frontend.env.GW_CAP_CONFIGURATION_FILENAME` | Filename to fetch CAP Warnings configured feeds | `capWarningPresets.json` |
+| `frontend.env.GW_TIMESERIES_CONFIGURATION_FILENAME` | Filename to fetch TimeSeries preset locations | `timeSeriesPresetLocations.json` |
 | `frontend.env.GW_SCREEN_PRESETS_FILENAME` | Filename to fetch screen presets | `screenPresets.json` |
 | `frontend.env.GW_FEATURE_FORCE_AUTHENTICATION` | Force authentication (block Guest access) | `false` |
 | `frontend.env.GW_FEATURE_MODULE_SPACE_WEATHER` | Enable Space Weather module | `false` |
@@ -137,4 +155,13 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 | `frontend.env.GW_AIRMET_BASE_URL` | Url which the application uses to connect to AIRMET backend | |
 | `frontend.env.GW_FEATURE_MODULE_SIGMET_CONFIGURATION` | Configuration used by SIGMET module | |
 | `frontend.env.GW_FEATURE_MODULE_AIRMET_CONFIGURATION` | Configuration used by AIRMET module | |
+| `frontend.useCustomConfigurationFiles` | Use custom configurations | `false` |
+| `frontend.customConfigurationLocation` | Where custom configurations are located *(local\|s3)* | `local` |
+| `frontend.volumeAccessMode` | Permissions of the application for the custom configurations PersistentVolume used | `ReadOnlyMany` |
+| `frontend.volumeSize` | Size of the custom configurations PersistentVolume | `100Mi` |
+| `frontend.customConfigurationFolderPath` | Path to the folder which contains custom configurations | |
+| `frontend.s3bucketName` | Name of the S3 bucket where custom configurations are stored | |
+| `frontend.awsAccessKeyId` | AWS_ACCESS_KEY_ID for authenticating to S3 | |
+| `frontend.awsAccessKeySecret` | AWS_SECRET_ACCESS_KEY for authenticating to S3 | |
+| `frontend.awsDefaultRegion` | Region where your S3 bucket is located | |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |

--- a/charts/geoweb-frontend/templates/geoweb-configmap.yaml
+++ b/charts/geoweb-frontend/templates/geoweb-configmap.yaml
@@ -25,26 +25,17 @@ data:
 {{- if .Values.frontend.env.GW_APP_URL }}
   GW_APP_URL: {{ .Values.frontend.env.GW_APP_URL | quote }}
 {{- end }}
-{{- if .Values.frontend.env.GW_GITLAB_PRESETS_BASE_URL }}
-  GW_GITLAB_PRESETS_BASE_URL: {{ .Values.frontend.env.GW_GITLAB_PRESETS_BASE_URL | quote }}
-{{- end }}
-{{- if .Values.frontend.env.GW_GITLAB_PRESETS_API_PATH }}
-  GW_GITLAB_PRESETS_API_PATH: {{ .Values.frontend.env.GW_GITLAB_PRESETS_API_PATH | quote }}
-{{- end }}
-{{- if .Values.frontend.env.GW_GITLAB_PROJECT_ID }}
-  GW_GITLAB_PROJECT_ID: {{ .Values.frontend.env.GW_GITLAB_PROJECT_ID | quote }}
-{{- end }}
-{{- if .Values.frontend.env.GW_GITLAB_PRESETS_PATH }}
-  GW_GITLAB_PRESETS_PATH: {{ .Values.frontend.env.GW_GITLAB_PRESETS_PATH | quote }}
-{{- end }}
-{{- if .Values.frontend.env.GW_GITLAB_BRANCH }}
-  GW_GITLAB_BRANCH: {{ .Values.frontend.env.GW_GITLAB_BRANCH | quote }}
-{{- end }}
 {{- if .Values.frontend.env.GW_INITIAL_PRESETS_FILENAME }}
   GW_INITIAL_PRESETS_FILENAME: {{ .Values.frontend.env.GW_INITIAL_PRESETS_FILENAME | quote }}
 {{- end }}
 {{- if .Values.frontend.env.GW_SCREEN_PRESETS_FILENAME }}
   GW_SCREEN_PRESETS_FILENAME: {{ .Values.frontend.env.GW_SCREEN_PRESETS_FILENAME | quote }}
+{{- end }}
+{{- if .Values.frontend.env.GW_CAP_CONFIGURATION_FILENAME }}
+  GW_CAP_CONFIGURATION_FILENAME: {{ .Values.frontend.env.GW_CAP_CONFIGURATION_FILENAME | quote }}
+{{- end }}
+{{- if .Values.frontend.env.GW_TIMESERIES_CONFIGURATION_FILENAME }}
+  GW_TIMESERIES_CONFIGURATION_FILENAME: {{ .Values.frontend.env.GW_TIMESERIES_CONFIGURATION_FILENAME | quote }}
 {{- end }}
 {{- if .Values.frontend.env.GW_DEFAULT_THEME }}
   GW_DEFAULT_THEME: {{ .Values.frontend.env.GW_DEFAULT_THEME | quote }}

--- a/charts/geoweb-frontend/templates/geoweb-deployment.yaml
+++ b/charts/geoweb-frontend/templates/geoweb-deployment.yaml
@@ -22,6 +22,22 @@ spec:
     {{- if eq .Values.secretProvider "aws" }}
       serviceAccountName: {{ .Values.frontend.secretServiceAccount }}
     {{- end }}
+    {{- if and .Values.frontend.useCustomConfigurationFiles (eq .Values.frontend.customConfigurationLocation "s3")}}
+      initContainers:
+      - name: init
+        image: amazon/aws-cli
+        command: ["/bin/sh"]
+        args:
+          - -c
+          - |
+            export AWS_ACCESS_KEY_ID={{ .Values.frontend.awsAccessKeyId }};
+            export AWS_SECRET_ACCESS_KEY={{ .Values.frontend.awsAccessKeySecret }};
+            AWS_DEFAULT_REGION={{ .Values.frontend.awsDefaultRegion }};
+            aws s3 cp --recursive s3://{{ .Values.frontend.s3bucketName }}{{ .Values.frontend.customConfigurationFolderPath }} /frontend;
+        volumeMounts:
+        - mountPath: "/frontend/"
+          name: {{ .Values.frontend.name }}-volume
+    {{- end }}
       containers:
       - name: {{ .Values.frontend.name }}
         image: {{ .Values.frontend.registry }}:{{ .Values.versions.frontend }}
@@ -33,18 +49,34 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ .Values.frontend.name }}
-    {{- if .Values.frontend.client_id_secret }}
+      {{- if .Values.frontend.client_id_secret }}
         env:
         - name: GW_AUTH_CLIENT_ID
           valueFrom:
             secretKeyRef:
               name: {{ .Values.frontend.client_id_secretName }}
               key: GW_AUTH_CLIENT_ID
+      {{- end }}
         volumeMounts:
+      {{- if .Values.secretProvider }}
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
           readOnly: true
+      {{- end }}
+      {{- if and .Values.frontend.useCustomConfigurationFiles }}
+        - mountPath: "/usr/share/nginx/html/assets/custom"
+          name: {{ .Values.frontend.name }}-volume
+      {{- end }}
       volumes:
+    {{- if .Values.frontend.useCustomConfigurationFiles }}
+      - name: {{ .Values.frontend.name }}-volume
+      {{- if eq .Values.frontend.customConfigurationLocation "s3"}}
+        emptyDir: {}
+      {{- else if eq .Values.frontend.customConfigurationLocation "local"}}
+        persistentVolumeClaim:
+          claimName: {{ .Values.frontend.name }}-claim
+      {{- end }}
+    {{- end }}
       - name: secrets-store-inline
       {{- if .Values.secretProvider }}
         csi:
@@ -56,4 +88,3 @@ spec:
         secret:
           secretName: {{ .Values.frontend.client_id_secretName | quote }}
       {{- end }}
-    {{- end }}

--- a/charts/geoweb-frontend/templates/geoweb-volume.yaml
+++ b/charts/geoweb-frontend/templates/geoweb-volume.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.frontend.useCustomConfigurationFiles (eq .Values.frontend.customConfigurationLocation "local")}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.frontend.name }}-claim
+spec:
+  storageClassName: ""
+  accessModes:
+    - {{ .Values.frontend.volumeAccessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.frontend.volumeSize }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.frontend.name }}-volume
+spec:
+  storageClassName: manual
+  capacity:
+    storage: {{ .Values.frontend.volumeSize }}
+  accessModes:
+    - {{ .Values.frontend.volumeAccessMode }}
+  claimRef:
+    namespace: {{ .Release.Namespace }}
+    name: {{ .Values.frontend.name }}-claim
+  hostPath:
+    path: {{ .Values.frontend.customConfigurationFolderPath | quote }}
+{{- end }}

--- a/charts/geoweb-frontend/values.yaml
+++ b/charts/geoweb-frontend/values.yaml
@@ -1,5 +1,5 @@
 versions:
-  frontend: "v4.19.1"
+  frontend: "v5.0.1"
 
 frontend:
   name: geoweb
@@ -18,10 +18,8 @@ frontend:
     GW_AUTH_TOKEN_URL: https://gitlab.com/oauth/token
     GW_AUTH_LOGIN_URL: https://gitlab.com/oauth/authorize?client_id={client_id}&response_type=code&scope=email+openid+read_repository+read_api&redirect_uri={app_url}/code&state={state}&code_challenge={code_challenge}&code_challenge_method=S256
     GW_INFRA_BASE_URL: https://api.opengeoweb.com
-    GW_GITLAB_PRESETS_BASE_URL: https://gitlab.com/api/v4/projects
-    GW_GITLAB_PRESETS_API_PATH: /{project_id}/repository/files/{presets_path}{preset_filename}/raw?ref={branch}
-    GW_GITLAB_PROJECT_ID: "24089222"
-    GW_GITLAB_BRANCH: master
+    GW_CAP_CONFIGURATION_FILENAME: capWarningPresets.json
+    GW_TIMESERIES_CONFIGURATION_FILENAME: timeSeriesPresetLocations.json
     GW_INITIAL_PRESETS_FILENAME: initialPresets.json
     GW_SCREEN_PRESETS_FILENAME: screenPresets.json
     GW_FEATURE_FORCE_AUTHENTICATION: false


### PR DESCRIPTION
* Custom configuration options to frontend chart
    * Functionality copied from geoweb-presets-backend, possibility to provide them from local folder or s3
* Updated appVersion to v5.0.1 (latest, includes new variables)
* Removed deprecated GW_GITLAB variables