### PR TITLE
Add custom caching policies for geoweb files 

### DIFF
--- a/charts/geoweb-frontend/Chart.yaml
+++ b/charts/geoweb-frontend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.2
+version: 2.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-frontend/README.md
+++ b/charts/geoweb-frontend/README.md
@@ -163,3 +163,4 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 | `frontend.awsAccessKeySecret` | AWS_SECRET_ACCESS_KEY for authenticating to S3 | |
 | `frontend.awsDefaultRegion` | Region where your S3 bucket is located | |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |
+| `ingress.rules` | Extra nginx configuration rules, like cache headers | See reference in `values.yaml` |

--- a/charts/geoweb-frontend/templates/nginx-ingress.yaml
+++ b/charts/geoweb-frontend/templates/nginx-ingress.yaml
@@ -11,7 +11,11 @@ metadata:
     nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-methods: "DELETE, PUT, GET, POST, OPTIONS, PATCH, HEAD"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET"
+  {{- if .Values.ingress.rules }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+    {{- .Values.ingress.rules | nindent 6 }}
+  {{- end }}
 spec:
   ingressClassName: nginx
   rules:

--- a/charts/geoweb-frontend/values.yaml
+++ b/charts/geoweb-frontend/values.yaml
@@ -30,4 +30,11 @@ frontend:
     GW_FEATURE_MENU_FE_VERSION: true
 
 ingress:
-  name: nginx-ingress-controller # Sync with nginx-ingress-controller/values.yaml
+  name: nginx-ingress-controller
+  rules: |
+    if ($request_uri ~* \.(json)) {
+      add_header Cache-Control "no-cache";
+    }
+    if ($request_uri ~* \.(woff2|svg|webmanifest)) {
+      add_header Cache-Control "max-age=604800";
+    }


### PR DESCRIPTION
Add custom caching policies for geoweb files & possibility to customize the rules with variables
* Added ingress.rules variable with some defaults (.json files should always be validated mainly)
    * Most files don't need any changes and work fine as they have randomized names and 10y max-age, so when new version of the file is used, the file name changes and it can't be fetched from cache.
* Reduced allowed methods to only GET as others aren't needed in the frontend

Closes https://gitlab.com/opengeoweb/opengeoweb/-/issues/4069