### PR TITLE
Set nginx as default ingressclassname

### DIFF
--- a/charts/geoweb-cap-backend/Chart.yaml
+++ b/charts/geoweb-cap-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-cap-backend/README.md
+++ b/charts/geoweb-cap-backend/README.md
@@ -54,5 +54,5 @@ The following table lists the configurable parameters of the CAP backend chart a
 | `cap.containerPort` | Port used for container | `8080` |
 | `cap.replicas` | Amount of replicas deployed | `1` |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |
-| `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | |
+| `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | `nginx` |
 | `ingress.customAnnotations` | Custom annotations for ingress, for example <pre>customAnnotations:<br>  traefik.annotation: exampleValue</pre> Overrides default nginx annotations if set | |

--- a/charts/geoweb-cap-backend/values.yaml
+++ b/charts/geoweb-cap-backend/values.yaml
@@ -11,3 +11,4 @@ cap:
 
 ingress:
   name: nginx-ingress-controller
+  ingressClassName: nginx

--- a/charts/geoweb-frontend/Chart.yaml
+++ b/charts/geoweb-frontend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.0
+version: 2.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-frontend/README.md
+++ b/charts/geoweb-frontend/README.md
@@ -163,6 +163,6 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 | `frontend.awsAccessKeySecret` | AWS_SECRET_ACCESS_KEY for authenticating to S3 | |
 | `frontend.awsDefaultRegion` | Region where your S3 bucket is located | |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |
-| `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | |
+| `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | `nginx` |
 | `ingress.rules` | Extra nginx configuration rules, like cache headers | See reference in `values.yaml` |
 | `ingress.customAnnotations` | Custom annotations for ingress, for example <pre>customAnnotations:<br>  traefik.annotation: exampleValue</pre> Overrides default nginx annotations and `frontend.auth_secret`, `frontend.auth_secretName` and `ingress.rules` can't be used if set | |

--- a/charts/geoweb-frontend/values.yaml
+++ b/charts/geoweb-frontend/values.yaml
@@ -38,3 +38,4 @@ ingress:
     if ($request_uri ~* \.(woff2|svg|webmanifest)) {
       add_header Cache-Control "max-age=604800";
     }
+  ingressClassName: nginx

--- a/charts/geoweb-opmet-backend/Chart.yaml
+++ b/charts/geoweb-opmet-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.0
+version: 2.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-opmet-backend/README.md
+++ b/charts/geoweb-opmet-backend/README.md
@@ -99,5 +99,5 @@ The following table lists the configurable parameters of the Opmet backend chart
 | `opmet.publisher.DESTINATION` | Folder inside publisher container where TACs are stored | `/app/output` |
 | `opmet.publisher.volumeOptions` | yaml including the definition of the volume where TACs are published to, for example: <pre>hostPath:<br>&nbsp;&nbsp; path: /test/path</pre> or <pre>emptyDir:<br>&nbsp;&nbsp;</pre>| `emptyDir:` |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |
-| `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | |
+| `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | `nginx` |
 | `ingress.customAnnotations` | Custom annotations for ingress, for example <pre>customAnnotations:<br>  traefik.annotation: exampleValue</pre> Overrides default nginx annotations if set | |

--- a/charts/geoweb-opmet-backend/values.yaml
+++ b/charts/geoweb-opmet-backend/values.yaml
@@ -38,3 +38,4 @@ opmet:
 
 ingress:
   name: nginx-ingress-controller
+  ingressClassName: nginx

--- a/charts/geoweb-presets-backend/Chart.yaml
+++ b/charts/geoweb-presets-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0
+version: 2.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-presets-backend/README.md
+++ b/charts/geoweb-presets-backend/README.md
@@ -116,5 +116,5 @@ The following table lists the configurable parameters of the Presets backend cha
 | `presets.awsAccessKeySecret` | AWS_SECRET_ACCESS_KEY for authenticating to S3 | |
 | `presets.awsDefaultRegion` | Region where your S3 bucket is located | |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |
-| `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | |
+| `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | `nginx` |
 | `ingress.customAnnotations` | Custom annotations for ingress, for example <pre>customAnnotations:<br>  traefik.annotation: exampleValue</pre> Overrides default nginx annotations if set | |

--- a/charts/geoweb-presets-backend/values.yaml
+++ b/charts/geoweb-presets-backend/values.yaml
@@ -28,3 +28,4 @@ presets:
 
 ingress:
   name: nginx-ingress-controller
+  ingressClassName: nginx

--- a/charts/geoweb-warnings-backend/Chart.yaml
+++ b/charts/geoweb-warnings-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-warnings-backend/README.md
+++ b/charts/geoweb-warnings-backend/README.md
@@ -84,5 +84,5 @@ The following table lists the configurable parameters of the Warnings backend ch
 | `warnings.nginx.WARNINGS_BACKEND_HOST` | Address where nginx accesses the backend | `0.0.0.0:8080` |
 | `warnings.nginx.NGINX_PORT_HTTP` | Port used for nginx | `80` |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |
-| `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | |
+| `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | `nginx` |
 | `ingress.customAnnotations` | Custom annotations for ingress, for example <pre>customAnnotations:<br>  traefik.annotation: exampleValue</pre> Overrides default nginx annotations if set | |

--- a/charts/geoweb-warnings-backend/values.yaml
+++ b/charts/geoweb-warnings-backend/values.yaml
@@ -23,3 +23,4 @@ warnings:
 
 ingress:
   name: nginx-ingress-controller # Sync with nginx-ingress-controller/values.yaml
+  ingressClassName: nginx


### PR DESCRIPTION
opengeoweb cluster default ingressclassname doesn't seem to work. Doing this change to helm-chart side so new deployments don't break. Should be reverted when issues on opengeoweb cluster are solved.