### PR TITLE
Add default resource requests & limits

### DIFF
--- a/charts/geoweb-cap-backend/Chart.yaml
+++ b/charts/geoweb-cap-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.1
+version: 1.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-cap-backend/README.md
+++ b/charts/geoweb-cap-backend/README.md
@@ -53,6 +53,7 @@ The following table lists the configurable parameters of the CAP backend chart a
 | `cap.svcPort` | Port used for service | `80` |
 | `cap.containerPort` | Port used for container | `8080` |
 | `cap.replicas` | Amount of replicas deployed | `1` |
+| `cap.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |
 | `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | `nginx` |
 | `ingress.customAnnotations` | Custom annotations for ingress, for example <pre>customAnnotations:<br>  traefik.annotation: exampleValue</pre> Overrides default nginx annotations if set | |

--- a/charts/geoweb-cap-backend/templates/cap-deployment.yaml
+++ b/charts/geoweb-cap-backend/templates/cap-deployment.yaml
@@ -27,3 +27,6 @@ spec:
       {{- end }}
         ports:
         - containerPort: {{ .Values.cap.containerPort}}
+      {{- if .Values.cap.resources }}
+        resources: {{ toYaml .Values.cap.resources | nindent 10 }}
+      {{- end }}

--- a/charts/geoweb-cap-backend/values.yaml
+++ b/charts/geoweb-cap-backend/values.yaml
@@ -8,6 +8,13 @@ cap:
   svcPort: 80
   containerPort: 8080
   replicas: 1
+  resources:
+    requests:
+      memory: "250Mi"
+      cpu: "50m"
+    limits:
+      memory: "350Mi"
+      cpu: "1"
 
 ingress:
   name: nginx-ingress-controller

--- a/charts/geoweb-frontend/Chart.yaml
+++ b/charts/geoweb-frontend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.1
+version: 3.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-frontend/README.md
+++ b/charts/geoweb-frontend/README.md
@@ -124,6 +124,7 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 | `frontend.client_id_secretKey` | Key of id secret | |
 | `frontend.iamRoleARN` | IAM Role with permissions to access secrets | |
 | `frontend.secretServiceAccount` | Service Account created for handling secrets | `geoweb-service-account` |
+| `frontend.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `secretProvider` | Option to use secret provider instead of passing base64 encoded Client ID as opmet.db_secret *(aws\|azure\|gcp\|vault)* | |
 | `secretProviderParameters` | Option to add custom parameters to the secretProvider, for example with aws you can specify region | |
 | `frontend.env.GW_CAP_BASE_URL` | Url which the application uses to connect to CAP backend | |

--- a/charts/geoweb-frontend/templates/geoweb-deployment.yaml
+++ b/charts/geoweb-frontend/templates/geoweb-deployment.yaml
@@ -46,6 +46,9 @@ spec:
       {{- end }}
         ports:
         - containerPort: {{ .Values.frontend.containerPort }}
+      {{- if .Values.frontend.resources }}
+        resources: {{ toYaml .Values.frontend.resources | nindent 10 }}
+      {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Values.frontend.name }}

--- a/charts/geoweb-frontend/values.yaml
+++ b/charts/geoweb-frontend/values.yaml
@@ -13,6 +13,13 @@ frontend:
   client_id_secretType: secretsmanager
   spcName: geoweb-spc
   secretServiceAccount: geoweb-service-account
+  resources:
+    requests:
+      memory: "100Mi"
+      cpu: "100m"
+    limits:
+      memory: "200Mi"
+      cpu: "1"
   env:
     GW_AUTH_LOGOUT_URL: "{app_url}"
     GW_AUTH_TOKEN_URL: https://gitlab.com/oauth/token

--- a/charts/geoweb-opmet-backend/Chart.yaml
+++ b/charts/geoweb-opmet-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.2
+version: 2.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-opmet-backend/README.md
+++ b/charts/geoweb-opmet-backend/README.md
@@ -73,6 +73,7 @@ The following table lists the configurable parameters of the Opmet backend chart
 | `opmet.db_secretKey` | Key of db secret | |
 | `opmet.iamRoleARN` | IAM Role with permissions to access db_secret secret | |
 | `opmet.secretServiceAccount` | Service Account created for handling secrets | `opmet-service-account` |
+| `opmet.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `secretProvider` | Option to use secret provider instead of passing base64 encoded database connection string as opmet.db_secret *(aws\|azure\|gcp\|vault)* | |
 | `secretProviderParameters` | Option to add custom parameters to the secretProvider, for example with aws you can specify region | |
 | `opmet.env.BACKEND_OPMET_PORT_HTTP` | Port used for container | `8000` |
@@ -86,6 +87,7 @@ The following table lists the configurable parameters of the Opmet backend chart
 | `opmet.messageconverter.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/avi-msgconverter/geoweb-knmi-avi-messageservices` |
 | `opmet.messageconverter.version` | Possibility to override application version | `"0.1.1"` |
 | `opmet.messageconverter.port` | Port used for messageconverter | `8080` |
+| `opmet.messageconverter.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `opmet.nginx.name` | Name of nginx container | `opmet-nginx` |
 | `opmet.nginx.registry` | Registry to fetch nginx image | `registry.gitlab.com/opengeoweb/backend-services/opmet-backend/nginx-opmet-backend` |
 | `opmet.nginx.OPMET_ENABLE_SSL` | Toggle SSL termination | `"FALSE"` |
@@ -93,11 +95,13 @@ The following table lists the configurable parameters of the Opmet backend chart
 | `opmet.nginx.NGINX_PORT_HTTP` | Port used for nginx | `80` |
 | `opmet.nginx.EXTERNAL_HOSTNAME` | - | `localhost:80` |
 | `opmet.nginx.OPMET_BACKEND_HOST` | Address where nginx accesses the backend | `localhost:8080` |
+| `opmet.nginx.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `opmet.publisher.name` | Name of publisher container  | `opmet-publisher` |
 | `opmet.publisher.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/backend-services/opmet-backend/opmet-backend-publisher-local` |
 | `opmet.publisher.port` | Port used for publisher | `8090`|
 | `opmet.publisher.DESTINATION` | Folder inside publisher container where TACs are stored | `/app/output` |
 | `opmet.publisher.volumeOptions` | yaml including the definition of the volume where TACs are published to, for example: <pre>hostPath:<br>&nbsp;&nbsp; path: /test/path</pre> or <pre>emptyDir:<br>&nbsp;&nbsp;</pre>| `emptyDir:` |
+| `opmet.publisher.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |
 | `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | `nginx` |
 | `ingress.customAnnotations` | Custom annotations for ingress, for example <pre>customAnnotations:<br>  traefik.annotation: exampleValue</pre> Overrides default nginx annotations if set | |

--- a/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
@@ -30,6 +30,9 @@ spec:
       {{- end }}
         ports:
         - containerPort: {{ .Values.opmet.env.OPMET_BACKEND_PORT_HTTP }}
+      {{- if .Values.opmet.resources }}
+        resources: {{ toYaml .Values.opmet.resources | nindent 10 }}
+      {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Values.opmet.name }}
@@ -52,6 +55,9 @@ spec:
       {{- end }}
         ports:
         - containerPort: {{ .Values.opmet.messageconverter.port }}
+      {{- if .Values.opmet.messageconverter.resources }}
+        resources: {{ toYaml .Values.opmet.messageconverter.resources | nindent 10 }}
+      {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Values.opmet.name }}
@@ -62,6 +68,9 @@ spec:
       {{- end }}
         ports:
         - containerPort: {{ .Values.opmet.publisher.port }}
+      {{- if .Values.opmet.publisher.resources }}
+        resources: {{ toYaml .Values.opmet.publisher.resources | nindent 10 }}
+      {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Values.opmet.publisher.name }}
@@ -75,6 +84,9 @@ spec:
       {{- end }}
         ports:
         - containerPort: {{ .Values.opmet.nginx.NGINX_PORT_HTTP }}
+      {{- if .Values.opmet.nginx.resources }}
+        resources: {{ toYaml .Values.opmet.nginx.resources | nindent 10 }}
+      {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Values.opmet.nginx.name }}

--- a/charts/geoweb-opmet-backend/values.yaml
+++ b/charts/geoweb-opmet-backend/values.yaml
@@ -11,6 +11,13 @@ opmet:
   db_secretType: secretsmanager
   spcName: opmet-spc
   secretServiceAccount: opmet-service-account
+  resources:
+    requests:
+      memory: "150Mi"
+      cpu: "50m"
+    limits:
+      memory: "300Mi"
+      cpu: "1"
   env:
     MESSAGECONVERTER_URL: "http://localhost:8080"
     OPMET_BACKEND_PORT_HTTP: 8000
@@ -23,11 +30,25 @@ opmet:
     registry: registry.gitlab.com/opengeoweb/avi-msgconverter/geoweb-knmi-avi-messageservices
     version: "0.1.1"
     port: 8080
+    resources:
+      requests:
+        memory: "250Mi"
+        cpu: "50m"
+      limits:
+        memory: "500Mi"
+        cpu: "1"
   publisher:
     name: opmet-publisher
     registry: registry.gitlab.com/opengeoweb/backend-services/opmet-backend/opmet-backend-publisher-local
     port: 8090
     DESTINATION: /app/output
+    resources:
+      requests:
+        memory: "50Mi"
+        cpu: "50m"
+      limits:
+        memory: "100Mi"
+        cpu: "1"
   nginx:
     name: opmet-nginx
     registry: registry.gitlab.com/opengeoweb/backend-services/opmet-backend/nginx-opmet-backend
@@ -35,6 +56,13 @@ opmet:
     NGINX_PORT_HTTP: 80
     EXTERNAL_HOSTNAME: localhost:80
     OPMET_BACKEND_HOST: localhost:8000
+    resources:
+      requests:
+        memory: "10Mi"
+        cpu: "10m"
+      limits:
+        memory: "100Mi"
+        cpu: "100m"
 
 ingress:
   name: nginx-ingress-controller

--- a/charts/geoweb-presets-backend/Chart.yaml
+++ b/charts/geoweb-presets-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.1
+version: 2.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-presets-backend/README.md
+++ b/charts/geoweb-presets-backend/README.md
@@ -98,6 +98,7 @@ The following table lists the configurable parameters of the Presets backend cha
 | `presets.db_secretKey` | Key of db secret | |
 | `presets.iamRoleARN` | IAM Role with permissions to access db_secret secret | |
 | `presets.secretServiceAccount` | Service Account created for handling secrets | `presets-service-account` |
+| `presets.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `secretProvider` | Option to use secret provider instead of passing base64 encoded database connection string as presets.db_secret *(aws\|azure\|gcp\|vault)* | |
 | `secretProviderParameters` | Option to add custom parameters to the secretProvider, for example with aws you can specify region | |
 | `presets.nginx.name` | Name of nginx container | `nginx` |
@@ -106,6 +107,7 @@ The following table lists the configurable parameters of the Presets backend cha
 | `presets.nginx.OAUTH2_USERINFO` | Userinfo endpoint to retrieve consented claims, or assertions, about the logged in end-user | - |
 | `presets.nginx.PRESETS_BACKEND_HOST` | Address where nginx accesses the backend | `0.0.0.0:8080` |
 | `presets.nginx.NGINX_PORT_HTTP` | Port used for nginx | `80` |
+| `presets.nginx.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `presets.useCustomWorkspacePresets` | Use custom presets | `false` |
 | `presets.customWorkspacePresetLocation` | Where custom presets are located *(local\|s3)* | `local` |
 | `presets.volumeAccessMode` | Permissions of the application for the custom presets PersistentVolume used | `ReadOnlyMany` |

--- a/charts/geoweb-presets-backend/templates/presets-deployment.yaml
+++ b/charts/geoweb-presets-backend/templates/presets-deployment.yaml
@@ -52,6 +52,9 @@ spec:
       {{- end }}
         ports:
         - containerPort: {{ .Values.presets.PRESETS_PORT_HTTP }}
+      {{- if .Values.presets.resources }}
+        resources: {{ toYaml .Values.presets.resources | nindent 10 }}
+      {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Values.presets.name }}
@@ -76,6 +79,9 @@ spec:
       {{- end }}
         ports:
         - containerPort: {{ .Values.presets.nginx.NGINX_PORT_HTTP }}
+      {{- if .Values.presets.nginx.resources }}
+        resources: {{ toYaml .Values.presets.nginx.resources | nindent 10 }}
+      {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Values.presets.nginx.name }}

--- a/charts/geoweb-presets-backend/values.yaml
+++ b/charts/geoweb-presets-backend/values.yaml
@@ -15,12 +15,26 @@ presets:
   db_secretType: secretsmanager
   spcName: presets-spc
   secretServiceAccount: presets-service-account
+  resources:
+    requests:
+      memory: "250Mi"
+      cpu: "50m"
+    limits:
+      memory: "350Mi"
+      cpu: "1"
   nginx:
     name: nginx
     registry: registry.gitlab.com/opengeoweb/backend-services/presets-backend/nginx-presets-backend
     PRESETS_ENABLE_SSL: "FALSE"
     PRESETS_BACKEND_HOST: 0.0.0.0:8080
     NGINX_PORT_HTTP: 80
+    resources:
+      requests:
+        memory: "10Mi"
+        cpu: "10m"
+      limits:
+        memory: "100Mi"
+        cpu: "100m"
   useCustomWorkspacePresets: false
   customWorkspacePresetLocation: local
   volumeAccessMode: ReadOnlyMany

--- a/charts/geoweb-taf-backend/Chart.yaml
+++ b/charts/geoweb-taf-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-taf-backend/README.md
+++ b/charts/geoweb-taf-backend/README.md
@@ -73,6 +73,7 @@ The following table lists the configurable parameters of the Taf backend chart a
 | `taf.db_secretKey` | Key of db secret | |
 | `taf.iamRoleARN` | IAM Role with permissions to access db_secret secret | |
 | `taf.secretServiceAccount` | Service Account created for handling secrets | `taf-service-account` |
+| `taf.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `secretProvider` | Option to use secret provider instead of passing base64 encoded database connection string as taf.db_secret *(aws\|azure\|gcp\|vault)* | |
 | `secretProviderParameters` | Option to add custom parameters to the secretProvider, for example with aws you can specify region | |
 | `taf.env.AVIATION_TAF_PORT_HTTP` | Port used for container | `8000` |
@@ -83,6 +84,7 @@ The following table lists the configurable parameters of the Taf backend chart a
 | `taf.messageconverter.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/avi-msgconverter/geoweb-knmi-avi-messageservices` |
 | `taf.messageconverter.version` | Possibility to override application version | `"0.1.1"` |
 | `taf.messageconverter.port` | Port used for messageconverter | `8080` |
+| `taf.messageconverter.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `taf.nginx.name` | Name of nginx container | `taf-nginx` |
 | `taf.nginx.registry` | Registry to fetch nginx image | `registry.gitlab.com/opengeoweb/backend-services/aviation-taf-backend/nginx-aviation-taf-backend` |
 | `taf.nginx.AVIATION_TAF_ENABLE_SSL` | Toggle SSL termination | `"FALSE"` |
@@ -90,15 +92,18 @@ The following table lists the configurable parameters of the Taf backend chart a
 | `taf.nginx.NGINX_PORT_HTTP` | Port used for nginx | `80` |
 | `taf.nginx.EXTERNAL_HOSTNAME` | - | `localhost:80` |
 | `taf.nginx.AVIATION_TAF_BACKEND_HOST` | Address where nginx accesses the backend | `localhost:8080` |
+| `taf.nginx.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `taf.publisher.name` | Name of publisher container  | `taf-publisher` |
 | `taf.publisher.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/backend-services/aviation-taf-backend/aviation-taf-backend-publisher-local` |
 | `taf.publisher.port` | Port used for publisher | `8090`|
 | `taf.publisher.DESTINATION` | Folder inside publisher container where TACs are stored | `/app/output` |
 | `taf.publisher.volumeOptions` | yaml including the definition of the volume where TACs are published to, for example: <pre>hostPath:<br>&nbsp;&nbsp; path: /test/path</pre> or <pre>emptyDir:<br>&nbsp;&nbsp;</pre>| `emptyDir:` |
+| `taf.publisher.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `taf.placeholder.name` | Name of publisher container  | `taf-placeholder` |
 | `taf.placeholder.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/backend-services/aviation-taf-backend/tafplaceholder-aviation-taf-backend` |
 | `taf.placeholder.port` | Port used for tafplaceholder | `8085` |
 | `taf.placeholder.TAFPLACEHOLDER_KEEPRUNNING` | - | `TRUE` |
+| `taf.placeholder.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |
 | `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | |
 | `ingress.customAnnotations` | Custom annotations for ingress, for example <pre>customAnnotations:<br>  traefik.annotation: exampleValue</pre> Overrides default nginx annotations if set | |

--- a/charts/geoweb-taf-backend/templates/taf-deployment.yaml
+++ b/charts/geoweb-taf-backend/templates/taf-deployment.yaml
@@ -36,6 +36,9 @@ spec:
       {{- end }}
         ports:
         - containerPort: {{ .Values.taf.env.AVIATION_TAF_PORT_HTTP }}
+      {{- if .Values.taf.resources }}
+        resources: {{ toYaml .Values.taf.resources | nindent 10 }}
+      {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Values.taf.name }}
@@ -56,6 +59,9 @@ spec:
       {{- end }}
         ports:
         - containerPort: {{ .Values.taf.placeholder.port }}
+      {{- if .Values.taf.placeholder.resources }}
+        resources: {{ toYaml .Values.taf.placeholder.resources | nindent 10 }}
+      {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Values.taf.placeholder.name }}
@@ -79,6 +85,9 @@ spec:
           value: {{ .Values.taf.messageconverter.port | quote }}
         ports:
         - containerPort: {{ .Values.taf.messageconverter.port }}
+      {{- if .Values.taf.messageconverter.resources }}
+        resources: {{ toYaml .Values.taf.messageconverter.resources | nindent 10 }}
+      {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Values.taf.name }}
@@ -89,6 +98,9 @@ spec:
       {{- end }}
         ports:
         - containerPort: {{ .Values.taf.publisher.port }}
+      {{- if .Values.taf.publisher.resources }}
+        resources: {{ toYaml .Values.taf.publisher.resources | nindent 10 }}
+      {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Values.taf.publisher.name }}
@@ -102,6 +114,9 @@ spec:
       {{- end }}
         ports:
         - containerPort: {{ .Values.taf.nginx.NGINX_PORT_HTTP }}
+      {{- if .Values.taf.nginx.resources }}
+        resources: {{ toYaml .Values.taf.nginx.resources | nindent 10 }}
+      {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Values.taf.nginx.name }}

--- a/charts/geoweb-taf-backend/values.yaml
+++ b/charts/geoweb-taf-backend/values.yaml
@@ -12,6 +12,13 @@ taf:
   spcName: taf-spc
   postStartCommand: bin/admin.sh
   secretServiceAccount: taf-service-account
+  resources:
+    requests:
+      memory: "250Mi"
+      cpu: "50m"
+    limits:
+      memory: "500Mi"
+      cpu: "1"
   env:
     GEOWEB_KNMI_AVI_MESSAGESERVICES_HOST: "localhost:8081"
     AVIATION_TAF_PORT_HTTP: 8000
@@ -21,11 +28,25 @@ taf:
     registry: registry.gitlab.com/opengeoweb/avi-msgconverter/geoweb-knmi-avi-messageservices
     version: "0.1.3"
     port: 8081
+    resources:
+      requests:
+        memory: "250Mi"
+        cpu: "50m"
+      limits:
+        memory: "500Mi"
+        cpu: "1"
   publisher:
     name: taf-publisher
     registry: registry.gitlab.com/opengeoweb/backend-services/aviation-taf-backend/aviation-taf-backend-publisher-local
     port: 8090
     DESTINATION: /app/output
+    resources:
+      requests:
+        memory: "50Mi"
+        cpu: "50m"
+      limits:
+        memory: "100Mi"
+        cpu: "1"
   nginx:
     name: taf-nginx
     registry: registry.gitlab.com/opengeoweb/backend-services/aviation-taf-backend/nginx-aviation-taf-backend
@@ -33,11 +54,25 @@ taf:
     NGINX_PORT_HTTP: 80
     EXTERNAL_HOSTNAME: localhost:80
     AVIATION_TAF_BACKEND_HOST: localhost:8000
+    resources:
+      requests:
+        memory: "10Mi"
+        cpu: "10m"
+      limits:
+        memory: "100Mi"
+        cpu: "100m"
   placeholder:
     name: taf-placeholder
     registry: registry.gitlab.com/opengeoweb/backend-services/aviation-taf-backend/tafplaceholder-aviation-taf-backend
     port: 8085
     TAFPLACEHOLDER_KEEPRUNNING: true
+    resources:
+      requests:
+        memory: "50Mi"
+        cpu: "50m"
+      limits:
+        memory: "100Mi"
+        cpu: "1"
 
 ingress:
   name: nginx-ingress-controller

--- a/charts/geoweb-warnings-backend/Chart.yaml
+++ b/charts/geoweb-warnings-backend/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.4"
+appVersion: "0.0.6"

--- a/charts/geoweb-warnings-backend/README.md
+++ b/charts/geoweb-warnings-backend/README.md
@@ -57,7 +57,7 @@ The following table lists the configurable parameters of the Warnings backend ch
 
 | Parameter | Description | Default |
 | - | - | - |
-| `versions.warnings` | Possibility to override application version | `0.0.4` |
+| `versions.warnings` | Possibility to override application version | `0.0.6` |
 | `warnings.name` | Name of backend | `warnings` |
 | `warnings.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/backend-services/warnings-backend` |
 | `warnings.commitHash` | Adds commitHash annotation to the deployment | |
@@ -75,6 +75,7 @@ The following table lists the configurable parameters of the Warnings backend ch
 | `warnings.db_secretKey` | Key of db secret | |
 | `warnings.iamRoleARN` | IAM Role with permissions to access db_secret secret | |
 | `warnings.secretServiceAccount` | Service Account created for handling secrets | `warnings-service-account` |
+| `warnings.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `secretProvider` | Option to use secret provider instead of passing base64 encoded database connection string as warnings.db_secret *(aws\|azure\|gcp\|vault)* | |
 | `secretProviderParameters` | Option to add custom parameters to the secretProvider, for example with aws you can specify region | |
 | `warnings.nginx.name` | Name of nginx container | `nginx` |
@@ -83,6 +84,7 @@ The following table lists the configurable parameters of the Warnings backend ch
 | `warnings.nginx.OAUTH2_USERINFO` | Userinfo endpoint to retrieve consented claims, or assertions, about the logged in end-user | - |
 | `warnings.nginx.WARNINGS_BACKEND_HOST` | Address where nginx accesses the backend | `0.0.0.0:8080` |
 | `warnings.nginx.NGINX_PORT_HTTP` | Port used for nginx | `80` |
+| `warnings.nginx.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |
 | `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | `nginx` |
 | `ingress.customAnnotations` | Custom annotations for ingress, for example <pre>customAnnotations:<br>  traefik.annotation: exampleValue</pre> Overrides default nginx annotations if set | |

--- a/charts/geoweb-warnings-backend/templates/warnings-deployment.yaml
+++ b/charts/geoweb-warnings-backend/templates/warnings-deployment.yaml
@@ -36,6 +36,9 @@ spec:
       {{- end }}
         ports:
         - containerPort: {{ .Values.warnings.WARNINGS_PORT_HTTP }}
+      {{- if .Values.warnings.resources }}
+        resources: {{ toYaml .Values.warnings.resources | nindent 10 }}
+      {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Values.warnings.name }}
@@ -56,6 +59,9 @@ spec:
       {{- end }}
         ports:
         - containerPort: {{ .Values.warnings.nginx.NGINX_PORT_HTTP }}
+      {{- if .Values.warnings.nginx.resources }}
+        resources: {{ toYaml .Values.warnings.nginx.resources | nindent 10 }}
+      {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Values.warnings.nginx.name }}

--- a/charts/geoweb-warnings-backend/values.yaml
+++ b/charts/geoweb-warnings-backend/values.yaml
@@ -1,5 +1,5 @@
 versions:
-  warnings: "0.0.4"
+  warnings: "0.0.6"
 
 warnings:
   name: warnings
@@ -14,12 +14,26 @@ warnings:
   db_secretType: secretsmanager
   spcName: warnings-spc
   secretServiceAccount: warnings-service-account
+  resources:
+    requests:
+      memory: "250Mi"
+      cpu: "50m"
+    limits:
+      memory: "400Mi"
+      cpu: "1"
   nginx:
     name: warnings-nginx
     registry: registry.gitlab.com/opengeoweb/backend-services/warnings-backend/nginx-warnings-backend
     WARNINGS_ENABLE_SSL: "FALSE"
     WARNINGS_BACKEND_HOST: 0.0.0.0:8080
     NGINX_PORT_HTTP: 80
+    resources:
+      requests:
+        memory: "10Mi"
+        cpu: "10m"
+      limits:
+        memory: "100Mi"
+        cpu: "100m"
 
 ingress:
   name: nginx-ingress-controller # Sync with nginx-ingress-controller/values.yaml


### PR DESCRIPTION
Adds default resource requests & limits for all geoweb charts, changes should include:
* Default values in values.yaml for each container
* Using resources variables in deployment yaml:s for each container
* Updated README to include requests for all containers
* Bump Chart versions

How to test:
* Code review, charts can also be deployed from local copy of the repository & using manual helm command
* Review if default values seem sensible: Most important value is the memory requests, which is used by kubernetes to determine which node the application pod should be deployed to. Current memory usage of pods can be checked with `kubectl top pod -A` (containers can be seen with --containers=true flag)

Some documentation about how different requests & limits are used by Kubernetes: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#how-pods-with-resource-limits-are-run

Closes https://gitlab.com/opengeoweb/fmi/fmi-aws-config/-/issues/73