### PR TITLE
[SOL-16523] Migrate fmi-nodeport and fmi-routes to common repo.

### DIFF
--- a/charts/fmi-nodeport/Chart.yaml
+++ b/charts/fmi-nodeport/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: fmi-nodeport
+description: Helm chart for defining api nodeport
+type: application
+version: 0.0.2
+keywords:
+  - fmi
+  - nodeport
+home: https://github.com/fmidev/fmi-public-helm-charts
+maintainers:
+  - name: Finnish Meteorological Institute
+    email: admin@weatherproof.fi
+    url: https://github.com/fmidev

--- a/charts/fmi-nodeport/Chart.yaml
+++ b/charts/fmi-nodeport/Chart.yaml
@@ -8,6 +8,6 @@ keywords:
   - nodeport
 home: https://github.com/fmidev/fmi-public-helm-charts
 maintainers:
-  - name: Finnish Meteorological Institute
+  - name: fmi-build-bot
     email: admin@weatherproof.fi
-    url: https://github.com/fmidev
+    url: https://github.com/fmi-build-bot

--- a/charts/fmi-nodeport/templates/nodeport.yaml
+++ b/charts/fmi-nodeport/templates/nodeport.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.nodeports }}
+{{- range $name, $nodeport := .Values.nodeports }}
+{{- if $nodeport.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}-nodeport
+  namespace: {{ $.Release.Namespace }}
+spec:
+  ports:
+  - name: {{ $name }}-service-port
+    nodePort: {{ $nodeport.apiPort }}
+    port: {{ $nodeport.servicePort }}
+    protocol: TCP
+    targetPort: {{ $nodeport.targetPodPort }}
+  selector:
+    app.kubernetes.io/instance: {{ $.Release.Namespace }}
+  type: NodePort
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/fmi-nodeport/values.yaml
+++ b/charts/fmi-nodeport/values.yaml
@@ -1,0 +1,3 @@
+# Intentionally empty default configuration
+fmi-nodeports:
+  nodeports:

--- a/charts/fmi-routes/.helmignore
+++ b/charts/fmi-routes/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/fmi-routes/Chart.yaml
+++ b/charts/fmi-routes/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: fmi-routes
+description: Helm chart for defining multiple routes
+type: application
+version: 0.0.8
+keywords:
+  - fmi
+  - route
+home: https://github.com/fmidev/fmi-public-helm-charts
+maintainers:
+  - name: Finnish Meteorological Institute
+    email: admin@weatherproof.fi
+    url: https://github.com/fmidev

--- a/charts/fmi-routes/Chart.yaml
+++ b/charts/fmi-routes/Chart.yaml
@@ -8,6 +8,6 @@ keywords:
   - route
 home: https://github.com/fmidev/fmi-public-helm-charts
 maintainers:
-  - name: Finnish Meteorological Institute
+  - name: fmi-build-bot
     email: admin@weatherproof.fi
-    url: https://github.com/fmidev
+    url: https://github.com/fmi-build-bot

--- a/charts/fmi-routes/templates/route.yaml
+++ b/charts/fmi-routes/templates/route.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.routes }}
+{{- range $name, $route := .Values.routes }}
+{{- if $route.enabled }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    type: {{ $route.type }}
+  {{- if $route.annotations }}
+  annotations:
+{{ toYaml $route.annotations | indent 4 }}
+  {{- end }}
+spec:
+  host: {{ $route.host }}
+  port:
+    targetPort: {{ $route.targetPort  }}
+  to:
+    kind: Service
+    name: {{ $route.targetService }}
+    weight: 100
+  wildcardPolicy: None
+  {{- if $route.tls }}
+  tls:
+    termination: {{ $route.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ $route.tls.insecureEdgeTerminationPolicy }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/fmi-routes/values.yaml
+++ b/charts/fmi-routes/values.yaml
@@ -1,0 +1,3 @@
+# Intentionally empty default configuration
+fmi-routes:
+  routes:


### PR DESCRIPTION
Contains pre-release chart versions:

* fmi-routes:0.0.8
* fmi-nodeport:0.0.2