### PR TITLE
docs(SOL-16523): Change fmi-routes chart home reference to correct url

### DIFF
--- a/charts/fmi-routes/Chart.yaml
+++ b/charts/fmi-routes/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.0.8
 keywords:
   - fmi
   - route
-home: https://github.com/fmidev/fmi-public-helm-charts
+home: https://github.com/fmidev/helm-charts
 maintainers:
   - name: fmi-build-bot
     email: admin@weatherproof.fi

--- a/charts/fmi-routes/Chart.yaml
+++ b/charts/fmi-routes/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fmi-routes
 description: Helm chart for defining multiple routes
 type: application
-version: 0.0.8
+version: 0.0.9
 keywords:
   - fmi
   - route


### PR DESCRIPTION
-  No changes to functionality
-  Fix fmi-routes Chart home url to correct repository url