### PR TITLE
Add custom configuration support to taf-backend chart

### DIFF
--- a/charts/geoweb-taf-backend/Chart.yaml
+++ b/charts/geoweb-taf-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-taf-backend/README.md
+++ b/charts/geoweb-taf-backend/README.md
@@ -7,7 +7,7 @@ helm repo update
 
 # Create requried dependencies
 
-Create values.yaml file for required variables:
+Create your own values file for required variables:
 * Using aws as the secret provider
 ```yaml
 taf: 
@@ -56,7 +56,7 @@ taf:
 Execute the following for testing the chart:
 
 ```bash
-helm install geoweb-taf-backend fmi/geoweb-taf-backend --dry-run --debug -n geoweb --values=./values.yaml
+helm install geoweb-taf-backend fmi/geoweb-taf-backend --dry-run --debug -n geoweb --values=./<yourvaluesfile>.yaml
 ```
 
 # Installing the Chart
@@ -64,7 +64,7 @@ helm install geoweb-taf-backend fmi/geoweb-taf-backend --dry-run --debug -n geow
 Execute the following for installing the chart:
 
 ```bash
-helm install geoweb-taf-backend fmi/geoweb-taf-backend -n geoweb --values=./values.yaml
+helm install geoweb-taf-backend fmi/geoweb-taf-backend -n geoweb --values=./<yourvaluesfile>.yaml
 ```
 
 # Deleting the Chart
@@ -78,7 +78,7 @@ kubectl delete namespace geoweb
 ```
 
 # Chart Configuration
-The following table lists the configurable parameters of the Taf backend chart and their default values.
+The following table lists the configurable parameters of the Taf backend chart and their default values specified in file values.yaml.
 
 | Parameter | Description | Default |
 | - | - | - |

--- a/charts/geoweb-taf-backend/README.md
+++ b/charts/geoweb-taf-backend/README.md
@@ -27,6 +27,31 @@ taf:
   db_secret: base64_encoded_postgresql_connection_string
 ```
 
+* Using custom configuration files stored locally
+```yaml
+taf:
+  env:
+    TAF_CONFIG: custom/config.ini
+  url: geoweb.example.com
+  useCustomConfigurationFiles: true
+  customConfigurationFolderPath: /example/path/
+```
+
+* Using custom configuration files stored in AWS S3
+```yaml
+taf:
+  url: geoweb.example.com
+  env:
+    TAF_CONFIG: custom/config.ini
+  useCustomConfigurationFiles: true
+  customConfigurationLocation: s3
+  s3bucketName: example-bucket
+  customConfigurationFolderPath: /example/path/
+  awsAccessKeyId: <AWS_ACCESS_KEY_ID>
+  awsAccessKeySecret: <AWS_SECRET_ACCESS_KEY>
+  awsDefaultRegion: <AWS_DEFAULT_REGION>
+```
+
 # Testing the Chart
 Execute the following for testing the chart:
 
@@ -82,6 +107,17 @@ The following table lists the configurable parameters of the Taf backend chart a
 | `taf.env.GEOWEB_KNMI_AVI_MESSAGESERVICES_HOST` | - | `"localhost:8081"` |
 | `taf.env.OAUTH2_USERINFO` | - | |
 | `taf.env.AVIATION_TAF_PUBLISH_HOST` | - | `"localhost:8090"` |
+| `taf.env.TAF_CONFIG` | Location of configuration file that is used (application defaults to `config.ini`) | |
+| `taf.useCustomConfigurationFiles` | Use custom configurations | `false` |
+| `taf.customConfigurationLocation` | Where custom configurations are located *(local\|s3)* | `local` |
+| `taf.volumeAccessMode` | Permissions of the application for the custom configurations PersistentVolume used | `ReadOnlyMany` |
+| `taf.volumeSize` | Size of the custom configurations PersistentVolume | `100Mi` |
+| `taf.customConfigurationFolderPath` | Path to the folder which contains custom configurations | |
+| `taf.customConfigurationMountPath` | Folder used to mount custom configurations | `/app/custom` |
+| `taf.s3bucketName` | Name of the S3 bucket where custom configurations are stored | |
+| `taf.awsAccessKeyId` | AWS_ACCESS_KEY_ID for authenticating to S3 | |
+| `taf.awsAccessKeySecret` | AWS_SECRET_ACCESS_KEY for authenticating to S3 | |
+| `taf.awsDefaultRegion` | Region where your S3 bucket is located | |
 | `taf.messageconverter.name` | Name of messageconverter container | `taf-messageconverter` |
 | `taf.messageconverter.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/avi-msgconverter/geoweb-knmi-avi-messageservices` |
 | `taf.messageconverter.version` | Possibility to override application version | `"0.1.1"` |

--- a/charts/geoweb-taf-backend/templates/taf-configmap.yaml
+++ b/charts/geoweb-taf-backend/templates/taf-configmap.yaml
@@ -10,5 +10,6 @@ data:
   GEOWEB_KNMI_AVI_MESSAGESERVICES_HOST: {{ .Values.taf.env.GEOWEB_KNMI_AVI_MESSAGESERVICES_HOST | quote }}
   AVIATION_TAF_PORT_HTTP: {{ .Values.taf.env.AVIATION_TAF_PORT_HTTP | quote }}
   AVIATION_TAF_PUBLISH_HOST: {{ .Values.taf.env.AVIATION_TAF_PUBLISH_HOST | quote }}
+  TAF_CONFIG: {{ .Values.taf.env.TAF_CONFIG | quote }}
   VERSION: {{ .Values.versions.taf | quote }}
   AVI_VERSION: {{ .Values.taf.messageconverter.version | quote }}

--- a/charts/geoweb-taf-backend/templates/taf-deployment.yaml
+++ b/charts/geoweb-taf-backend/templates/taf-deployment.yaml
@@ -33,7 +33,7 @@ spec:
             export AWS_ACCESS_KEY_ID={{ .Values.taf.awsAccessKeyId }};
             export AWS_SECRET_ACCESS_KEY={{ .Values.taf.awsAccessKeySecret }};
             AWS_DEFAULT_REGION={{ .Values.taf.awsDefaultRegion }};
-            aws s3 cp --recursive s3://{{ .Values.taf.s3bucketName }}{{ .Values.taf.customConfigurationFolderPath }} /taf;
+            aws s3 cp --recursive --exclude "*/*" s3://{{ .Values.taf.s3bucketName }}{{ .Values.taf.customConfigurationFolderPath }} /taf;
         volumeMounts:
         - mountPath: "/taf/"
           name: {{ .Values.taf.name }}-volume

--- a/charts/geoweb-taf-backend/templates/taf-deployment.yaml
+++ b/charts/geoweb-taf-backend/templates/taf-deployment.yaml
@@ -22,6 +22,22 @@ spec:
     {{- if eq .Values.secretProvider "aws" }}
       serviceAccountName: {{ .Values.taf.secretServiceAccount }}
     {{- end }}
+    {{- if and .Values.taf.useCustomConfigurationFiles (eq .Values.taf.customConfigurationLocation "s3")}}
+      initContainers:
+      - name: init
+        image: amazon/aws-cli
+        command: ["/bin/sh"]
+        args:
+          - -c
+          - |
+            export AWS_ACCESS_KEY_ID={{ .Values.taf.awsAccessKeyId }};
+            export AWS_SECRET_ACCESS_KEY={{ .Values.taf.awsAccessKeySecret }};
+            AWS_DEFAULT_REGION={{ .Values.taf.awsDefaultRegion }};
+            aws s3 cp --recursive s3://{{ .Values.taf.s3bucketName }}{{ .Values.taf.customConfigurationFolderPath }} /taf;
+        volumeMounts:
+        - mountPath: "/taf/"
+          name: {{ .Values.taf.name }}-volume
+    {{- end }}
       containers:
       - name: {{ .Values.taf.name }}
         image: {{ .Values.taf.registry }}:{{ .Values.versions.taf }}
@@ -58,6 +74,10 @@ spec:
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
           readOnly: true
+      {{- if and .Values.taf.useCustomConfigurationFiles }}
+        - mountPath: {{ .Values.taf.customConfigurationMountPath }}
+          name: {{ .Values.taf.name }}-volume
+      {{- end }}
       - name: {{ .Values.taf.placeholder.name }}
         image: {{ .Values.taf.placeholder.registry }}:{{ .Values.versions.taf }}
       {{- if .Values.taf.imagePullPolicy }}
@@ -164,6 +184,15 @@ spec:
             value: {{ .Values.taf.db.POSTGRES_PASSWORD }}
       {{- end }}
       volumes:
+    {{- if .Values.taf.useCustomConfigurationFiles }}
+      - name: {{ .Values.taf.name }}-volume
+      {{- if eq .Values.taf.customConfigurationLocation "s3"}}
+        emptyDir: {}
+      {{- else if eq .Values.taf.customConfigurationLocation "local"}}
+        persistentVolumeClaim:
+          claimName: {{ .Values.taf.name }}-claim
+      {{- end }}
+    {{- end }}
       - name: secrets-store-inline
       {{- if .Values.secretProvider }}
         csi:

--- a/charts/geoweb-taf-backend/templates/taf-volume.yaml
+++ b/charts/geoweb-taf-backend/templates/taf-volume.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.taf.useCustomConfigurationFiles (eq .Values.taf.customConfigurationLocation "local")}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.taf.name }}-claim
+spec:
+  storageClassName: ""
+  accessModes:
+    - {{ .Values.taf.volumeAccessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.taf.volumeSize }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.taf.name }}-volume
+spec:
+  storageClassName: manual
+  capacity:
+    storage: {{ .Values.taf.volumeSize }}
+  accessModes:
+    - {{ .Values.taf.volumeAccessMode }}
+  claimRef:
+    namespace: {{ .Release.Namespace }}
+    name: {{ .Values.taf.name }}-claim
+  hostPath:
+    path: {{ .Values.taf.customConfigurationFolderPath | quote }}
+{{- end }}

--- a/charts/geoweb-taf-backend/values.yaml
+++ b/charts/geoweb-taf-backend/values.yaml
@@ -152,6 +152,11 @@ taf:
     POSTGRES_DB: taf
     POSTGRES_USER: postgres
     POSTGRES_PASSWORD: postgres
+  useCustomConfigurationFiles: false
+  customConfigurationLocation: local
+  customConfigurationMountPath: /app/custom
+  volumeAccessMode: ReadOnlyMany
+  volumeSize: 100Mi
 
 ingress:
   name: nginx-ingress-controller


### PR DESCRIPTION
* Added optional TAF_CONFIG variable to configmap
* Added useCustomConfigurationFiles and other related variables for configuring the location of the custom configuration files
  * Implementation similar to geoweb-frontend configurations: https://github.com/fmidev/helm-charts/pull/19

How to test:
* Application using new chart is running at https://terraform.opengeoweb.com/taf, with custom configuration that removes the first location. This can be verified by pointing local frontend to this with GW_TAF_BASE_URL
* Code review

Closes https://gitlab.com/opengeoweb/opengeoweb/-/issues/4300