### PR TITLE
Add custom configuration support to opmet-backend chart

### DIFF
--- a/charts/geoweb-opmet-backend/Chart.yaml
+++ b/charts/geoweb-opmet-backend/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.5
+version: 2.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.3.0"
+appVersion: "v1.3.1"
 
 maintainers:
   - name: Jusaa

--- a/charts/geoweb-opmet-backend/README.md
+++ b/charts/geoweb-opmet-backend/README.md
@@ -27,6 +27,35 @@ opmet:
   db_secret: base64_encoded_postgresql_connection_string
 ```
 
+* Using custom configuration files stored locally
+```yaml
+opmet:
+  env:
+    BACKEND_CONFIG: configuration_files/custom/backendConfig.json
+    SIGMET_CONFIG: configuration_files/custom/sigmetConfig.json
+    AIRMET_CONFIG: configuration_files/custom/airmetConfig.json
+  url: geoweb.example.com
+  useCustomConfigurationFiles: true
+  customConfigurationFolderPath: /example/path/
+```
+
+* Using custom configuration files stored in AWS S3
+```yaml
+opmet:
+  url: geoweb.example.com
+  env:
+    BACKEND_CONFIG: configuration_files/custom/backendConfig.json
+    SIGMET_CONFIG: configuration_files/custom/sigmetConfig.json
+    AIRMET_CONFIG: configuration_files/custom/airmetConfig.json
+  useCustomConfigurationFiles: true
+  customConfigurationLocation: s3
+  s3bucketName: example-bucket
+  customConfigurationFolderPath: /example/path/
+  awsAccessKeyId: <AWS_ACCESS_KEY_ID>
+  awsAccessKeySecret: <AWS_SECRET_ACCESS_KEY>
+  awsDefaultRegion: <AWS_DEFAULT_REGION>
+```
+
 # Testing the Chart
 Execute the following for testing the chart:
 
@@ -57,7 +86,7 @@ The following table lists the configurable parameters of the Opmet backend chart
 
 | Parameter | Description | Default |
 | - | - | - |
-| `versions.opmet` | Possibility to override application version | `v1.3.0` |
+| `versions.opmet` | Possibility to override application version | `v1.3.1` |
 | `opmet.name` | Name of backend | `opmet` |
 | `opmet.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/backend-services/opmet-backend` |
 | `opmet.commitHash` | Adds commitHash annotation to the deployment | |
@@ -85,6 +114,19 @@ The following table lists the configurable parameters of the Opmet backend chart
 | `opmet.env.OPMET_ENABLE_SSL` | Toggle SSL termination | `"FALSE"` |
 | `opmet.env.FORWARDED_ALLOW_IPS` | - | `"*"` |
 | `opmet.env.PUBLISHER_URL` | - | `"http://localhost:8090/publish"` |
+| `opmet.env.BACKEND_CONFIG` | Location of backend configuration file that is used (application defaults to `configuration_files/backendConfig.json`) | |
+| `opmet.env.SIGMET_CONFIG` | Location of SIGMET configuration file that is used (application defaults to `configuration_files/sigmetConfig.json`) | |
+| `opmet.env.AIRMET_CONFIG` | Location of AIRMET configuration file that is used (application defaults to `configuration_files/airmetConfig.json`) | |
+| `opmet.useCustomConfigurationFiles` | Use custom configurations | `false` |
+| `opmet.customConfigurationLocation` | Where custom configurations are located *(local\|s3)* | `local` |
+| `opmet.volumeAccessMode` | Permissions of the application for the custom configurations PersistentVolume used | `ReadOnlyMany` |
+| `opmet.volumeSize` | Size of the custom configurations PersistentVolume | `100Mi` |
+| `opmet.customConfigurationFolderPath` | Path to the folder which contains custom configurations | |
+| `opmet.customConfigurationMountPath` | Folder used to mount custom configurations | `/app/custom` |
+| `opmet.s3bucketName` | Name of the S3 bucket where custom configurations are stored | |
+| `opmet.awsAccessKeyId` | AWS_ACCESS_KEY_ID for authenticating to S3 | |
+| `opmet.awsAccessKeySecret` | AWS_SECRET_ACCESS_KEY for authenticating to S3 | |
+| `opmet.awsDefaultRegion` | Region where your S3 bucket is located | |
 | `opmet.messageconverter.name` | Name of messageconverter container | `opmet-messageconverter` |
 | `opmet.messageconverter.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/avi-msgconverter/geoweb-knmi-avi-messageservices` |
 | `opmet.messageconverter.version` | Possibility to override application version | `"0.1.1"` |

--- a/charts/geoweb-opmet-backend/templates/opmet-configmap.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-configmap.yaml
@@ -14,3 +14,6 @@ data:
   OPMET_ENABLE_SSL: {{ .Values.opmet.env.OPMET_ENABLE_SSL | quote }}
   FORWARDED_ALLOW_IPS: {{ .Values.opmet.env.FORWARDED_ALLOW_IPS | quote }}
   PUBLISHER_URL: {{ .Values.opmet.env.PUBLISHER_URL | quote }}
+  BACKEND_CONFIG: {{ .Values.opmet.env.BACKEND_CONFIG | quote }}
+  SIGMET_CONFIG: {{ .Values.opmet.env.SIGMET_CONFIG | quote }}
+  AIRMET_CONFIG: {{ .Values.opmet.env.AIRMET_CONFIG | quote }}

--- a/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
@@ -22,6 +22,22 @@ spec:
     {{- if eq .Values.secretProvider "aws" }}
       serviceAccountName: {{ .Values.opmet.secretServiceAccount }}
     {{- end }}
+        {{- if and .Values.opmet.useCustomConfigurationFiles (eq .Values.opmet.customConfigurationLocation "s3")}}
+      initContainers:
+      - name: init
+        image: amazon/aws-cli
+        command: ["/bin/sh"]
+        args:
+          - -c
+          - |
+            export AWS_ACCESS_KEY_ID={{ .Values.opmet.awsAccessKeyId }};
+            export AWS_SECRET_ACCESS_KEY={{ .Values.opmet.awsAccessKeySecret }};
+            AWS_DEFAULT_REGION={{ .Values.opmet.awsDefaultRegion }};
+            aws s3 cp --recursive s3://{{ .Values.opmet.s3bucketName }}{{ .Values.opmet.customConfigurationFolderPath }} /opmet;
+        volumeMounts:
+        - mountPath: "/opmet/"
+          name: {{ .Values.opmet.name }}-volume
+    {{- end }}
       containers:
       - name: {{ .Values.opmet.name }}
         image: {{ .Values.opmet.registry }}:{{ .Values.versions.opmet }}
@@ -52,6 +68,10 @@ spec:
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
           readOnly: true
+      {{- if and .Values.opmet.useCustomConfigurationFiles }}
+        - mountPath: {{ .Values.opmet.customConfigurationMountPath }}
+          name: {{ .Values.opmet.name }}-volume
+      {{- end }}
         command: ["/bin/sh"]
         args: ["-c", "sleep 10 ; gunicorn --bind 0.0.0.0:8000 -k uvicorn.workers.UvicornWorker --log-config opmet_logging.conf opmet_backend.main:app"]
       - name: {{ .Values.opmet.messageconverter.name }}
@@ -128,6 +148,15 @@ spec:
             value: {{ .Values.opmet.db.POSTGRES_PASSWORD }}
       {{- end }}
       volumes:
+    {{- if .Values.opmet.useCustomConfigurationFiles }}
+      - name: {{ .Values.opmet.name }}-volume
+      {{- if eq .Values.opmet.customConfigurationLocation "s3"}}
+        emptyDir: {}
+      {{- else if eq .Values.opmet.customConfigurationLocation "local"}}
+        persistentVolumeClaim:
+          claimName: {{ .Values.opmet.name }}-claim
+      {{- end }}
+    {{- end }}
       - name: secrets-store-inline
       {{- if .Values.secretProvider }}
         csi:

--- a/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
@@ -33,7 +33,7 @@ spec:
             export AWS_ACCESS_KEY_ID={{ .Values.opmet.awsAccessKeyId }};
             export AWS_SECRET_ACCESS_KEY={{ .Values.opmet.awsAccessKeySecret }};
             AWS_DEFAULT_REGION={{ .Values.opmet.awsDefaultRegion }};
-            aws s3 cp --recursive s3://{{ .Values.opmet.s3bucketName }}{{ .Values.opmet.customConfigurationFolderPath }} /opmet;
+            aws s3 cp --recursive --exclude "*/*" s3://{{ .Values.opmet.s3bucketName }}{{ .Values.opmet.customConfigurationFolderPath }} /opmet;
         volumeMounts:
         - mountPath: "/opmet/"
           name: {{ .Values.opmet.name }}-volume

--- a/charts/geoweb-opmet-backend/templates/opmet-volume.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-volume.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.opmet.useCustomConfigurationFiles (eq .Values.opmet.customConfigurationLocation "local")}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.opmet.name }}-claim
+spec:
+  storageClassName: ""
+  accessModes:
+    - {{ .Values.opmet.volumeAccessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.opmet.volumeSize }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.opmet.name }}-volume
+spec:
+  storageClassName: manual
+  capacity:
+    storage: {{ .Values.opmet.volumeSize }}
+  accessModes:
+    - {{ .Values.opmet.volumeAccessMode }}
+  claimRef:
+    namespace: {{ .Release.Namespace }}
+    name: {{ .Values.opmet.name }}-claim
+  hostPath:
+    path: {{ .Values.opmet.customConfigurationFolderPath | quote }}
+{{- end }}

--- a/charts/geoweb-opmet-backend/values.yaml
+++ b/charts/geoweb-opmet-backend/values.yaml
@@ -1,5 +1,5 @@
 versions:
-  opmet: "v1.3.0"
+  opmet: "v1.3.1"
 
 opmet:
   name: opmet
@@ -128,6 +128,12 @@ opmet:
     POSTGRES_DB: opmet
     POSTGRES_USER: postgres
     POSTGRES_PASSWORD: postgres
+  useCustomConfigurationFiles: false
+  customConfigurationLocation: local
+  customConfigurationMountPath: /app/configuration_files/custom
+  volumeAccessMode: ReadOnlyMany
+  volumeSize: 100Mi
+
 ingress:
   name: nginx-ingress-controller
   ingressClassName: nginx


### PR DESCRIPTION
* Added optional BACKEND_CONFIG, SIGMET_CONFIG and AIRMET_CONFIG variables to configmap
  * These aren't yet implemented in the opmet backend code, so they don't do anything yet
* Added useCustomConfigurationFiles and other related variables for configuring the location of the custom configuration files
  * Implementation similar to taf-backend configurations: https://github.com/fmidev/helm-charts/pull/34
* Version bump to latest

How to test:
* Code review
* Chart can be applied with settings pointing to an example s3 bucket, so you could exec into the opmet pod and verify that the custom files are in fact present inside configuration_files/custom, ready to be used by the application
  * This is how I verified that it's working

Closes https://gitlab.com/opengeoweb/opengeoweb/-/issues/4287