### PR TITLE
Add extra options & missing config option

### DIFF
--- a/charts/geoweb-frontend/Chart.yaml
+++ b/charts/geoweb-frontend/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.5
+version: 3.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v8.2.0"
+appVersion: "v8.3.1"
 
 maintainers:
   - name: Jusaa

--- a/charts/geoweb-frontend/README.md
+++ b/charts/geoweb-frontend/README.md
@@ -7,7 +7,7 @@ helm repo update
 
 # Create requried dependencies
 
-Create values.yaml file for required variables:
+Create your own values file for required variables:
 
 * Minimal setup
 ```yaml
@@ -77,7 +77,7 @@ frontend:
 Execute the following for testing the chart:
 
 ```bash
-helm install geoweb-frontend fmi/geoweb-frontend --dry-run --debug -n geoweb --values=./values.yaml
+helm install geoweb-frontend fmi/geoweb-frontend --dry-run --debug -n geoweb --values=./<yourvaluesfile>.yaml
 ```
 
 # Installing the Chart
@@ -85,7 +85,7 @@ helm install geoweb-frontend fmi/geoweb-frontend --dry-run --debug -n geoweb --v
 Execute the following for installing the chart:
 
 ```bash
-helm install geoweb-frontend fmi/geoweb-frontend -n geoweb --values=./values.yaml
+helm install geoweb-frontend fmi/geoweb-frontend -n geoweb --values=./<yourvaluesfile>.yaml
 ```
 
 # Deleting the Chart
@@ -99,7 +99,7 @@ kubectl delete namespace geoweb
 ```
 
 # Chart Configuration
-The following table lists the configurable parameters of the GeoWeb frontend chart and their default values.
+The following table lists the configurable parameters of the GeoWeb frontend chart and their default values specified in file values.yaml.
 
 | Parameter | Description | Default |
 | - | - | - |

--- a/charts/geoweb-frontend/README.md
+++ b/charts/geoweb-frontend/README.md
@@ -103,7 +103,7 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 
 | Parameter | Description | Default |
 | - | - | - |
-| `versions.frontend` | Possibility to override application version | `v8.2.0` |
+| `versions.frontend` | Possibility to override application version | `v8.3.1` |
 | `frontend.name` | Name of frontend | `geoweb` |
 | `frontend.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/opengeoweb` |
 | `frontend.commitHash` | Adds commitHash annotation to the deployment | |
@@ -132,6 +132,7 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 | `frontend.env.GW_CAP_BASE_URL` | Url which the application uses to connect to CAP backend | |
 | `frontend.env.GW_DRAWINGS_BASE_URL` | Url which the application uses to connect to Drawings backend | |
 | `frontend.env.GW_TAF_BASE_URL` | Url which the application uses to connect to TAF backend | |
+| `frontend.env.GW_SW_BASE_URL` | Url which the application uses to connect to Space Weather backend | |
 | `frontend.env.GW_APP_URL` | Url which the application can be accessed | |
 | `frontend.env.GW_DEFAULT_THEME` | Default theme: lightMode or darkMode | |
 | `frontend.env.GW_FEATURE_APP_TITLE` | Application title | |
@@ -149,6 +150,7 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 | `frontend.env.GW_FEATURE_MENU_INFO` | Enable Info menu option | `true` |
 | `frontend.env.GW_FEATURE_MENU_VERSION` | Enable Version menu option | `false` |
 | `frontend.env.GW_FEATURE_MENU_FE_VERSION` | Enable FE Version menu option | `true` |
+| `frontend.env.GW_FEATURE_MENU_USER_DOCUMENTATION_URL` | Link to user documentation | |
 | `frontend.env.GW_SIGMET_BASE_URL` | Url which the application uses to connect to SIGMET backend | |
 | `frontend.env.GW_AIRMET_BASE_URL` | Url which the application uses to connect to AIRMET backend | |
 | `frontend.env.GW_FEATURE_MODULE_SIGMET_CONFIGURATION` | Configuration used by SIGMET module | |
@@ -158,6 +160,7 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 | `frontend.volumeAccessMode` | Permissions of the application for the custom configurations PersistentVolume used | `ReadOnlyMany` |
 | `frontend.volumeSize` | Size of the custom configurations PersistentVolume | `100Mi` |
 | `frontend.customConfigurationFolderPath` | Path to the folder which contains custom configurations | |
+| `frontend.customConfigurationMountPath` | Folder used to mount custom configurations | `/usr/share/nginx/html/assets/custom` |
 | `frontend.s3bucketName` | Name of the S3 bucket where custom configurations are stored | |
 | `frontend.awsAccessKeyId` | AWS_ACCESS_KEY_ID for authenticating to S3 | |
 | `frontend.awsAccessKeySecret` | AWS_SECRET_ACCESS_KEY for authenticating to S3 | |

--- a/charts/geoweb-frontend/templates/geoweb-configmap.yaml
+++ b/charts/geoweb-frontend/templates/geoweb-configmap.yaml
@@ -52,6 +52,9 @@ data:
 {{- if .Values.frontend.env.GW_TAF_BASE_URL }}
   GW_TAF_BASE_URL: {{ .Values.frontend.env.GW_TAF_BASE_URL | quote }}
 {{- end }}
+{{- if .Values.frontend.env.GW_SW_BASE_URL }}
+  GW_SW_BASE_URL: {{ .Values.frontend.env.GW_SW_BASE_URL | quote }}
+{{- end }}
 {{- if .Values.frontend.env.GW_FEATURE_MENU_FEEDBACK }}
   GW_FEATURE_MENU_FEEDBACK: {{ .Values.frontend.env.GW_FEATURE_MENU_FEEDBACK | quote }}
 {{- end }}

--- a/charts/geoweb-frontend/templates/geoweb-deployment.yaml
+++ b/charts/geoweb-frontend/templates/geoweb-deployment.yaml
@@ -33,7 +33,7 @@ spec:
             export AWS_ACCESS_KEY_ID={{ .Values.frontend.awsAccessKeyId }};
             export AWS_SECRET_ACCESS_KEY={{ .Values.frontend.awsAccessKeySecret }};
             AWS_DEFAULT_REGION={{ .Values.frontend.awsDefaultRegion }};
-            aws s3 cp --recursive s3://{{ .Values.frontend.s3bucketName }}{{ .Values.frontend.customConfigurationFolderPath }} /frontend;
+            aws s3 cp --recursive --exclude "*/*" s3://{{ .Values.frontend.s3bucketName }}{{ .Values.frontend.customConfigurationFolderPath }} /frontend;
         volumeMounts:
         - mountPath: "/frontend/"
           name: {{ .Values.frontend.name }}-volume

--- a/charts/geoweb-frontend/templates/geoweb-deployment.yaml
+++ b/charts/geoweb-frontend/templates/geoweb-deployment.yaml
@@ -73,7 +73,7 @@ spec:
           readOnly: true
       {{- end }}
       {{- if and .Values.frontend.useCustomConfigurationFiles }}
-        - mountPath: "/usr/share/nginx/html/assets/custom"
+        - mountPath: {{ .Values.frontend.customConfigurationMountPath }}
           name: {{ .Values.frontend.name }}-volume
       {{- end }}
       volumes:

--- a/charts/geoweb-frontend/values.yaml
+++ b/charts/geoweb-frontend/values.yaml
@@ -1,5 +1,5 @@
 versions:
-  frontend: "v8.2.0"
+  frontend: "v8.3.1"
 
 frontend:
   name: geoweb
@@ -45,6 +45,11 @@ frontend:
     GW_FEATURE_MENU_INFO: true
     GW_FEATURE_MENU_VERSION: false
     GW_FEATURE_MENU_FE_VERSION: true
+  useCustomConfigurationFiles: false
+  customConfigurationLocation: local
+  customConfigurationMountPath: /usr/share/nginx/html/assets/custom
+  volumeAccessMode: ReadOnlyMany
+  volumeSize: 100Mi
 
 ingress:
   name: nginx-ingress-controller


### PR DESCRIPTION
* Adds missing README & ConfigMap entries for GW_SW_BASE_URL and GW_FEATURE_MENU_USER_DOCUMENTATION_URL
* Adds customConfigurationMountPath variable to match the functionality in opmet/taf charts
* Adds default values for useCustomConfigurationFiles and some related variables
* Version bump

How to test:
* Code review is enough
* Installing the chart with custom configurations and exec inside the pod can be done to verify that the custom configurations still work
  * This is how I verified that it's working