### PR TITLE
Zalando Postgres database to Opmet backend

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -23,7 +23,7 @@ jobs:
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/charts/geoweb-opmet-backend/Chart.yaml
+++ b/charts/geoweb-opmet-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.0
+version: 2.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-opmet-backend/README.md
+++ b/charts/geoweb-opmet-backend/README.md
@@ -56,6 +56,17 @@ opmet:
   awsDefaultRegion: <AWS_DEFAULT_REGION>
 ```
 
+* Using Zalando Operator Database
+```yaml
+opmet:
+  url: geoweb.example.com
+  db:
+    enableDefaultDb: false
+    useZalandoOperatorDb: true
+    cleanInstall: false # Add this line only after first install
+    backupBucket: s3://<S3-bucket-name>/
+```
+
 # Testing the Chart
 Execute the following for testing the chart:
 
@@ -153,11 +164,20 @@ The following table lists the configurable parameters of the Opmet backend chart
 | `opmet.publisher.livenessProbe` | Configure libenessProbe | see defaults from `values.yaml` |
 | `opmet.publisher.readinessProbe` | Configure readinessProbe | see defaults from `values.yaml` |
 | `opmet.db.enableDefaultDb` | Enable default postgres database | `true` |
-| `opmet.db.name` | Default postgres database container name | `postgres` |
+| `opmet.db.useZalandoOperatorDb` | Enable postgres database with Zalando Postgres Operator | `false` |
+| `opmet.db.POSTGRES_VERSION` | Postgres version used by Zalando Postgres database | `15` |
+| `opmet.db.numberOfInstances` | Number of Zalando postgres database instances created | `1` |
+| `opmet.db.instanceSize` | Size of the volumes used by Zalando postgres database instances | `100Mi` |
+| `opmet.db.zalandoTeamId` | Team id of Zalando databases  | `geoweb` |
+| `opmet.db.enableLogicalBackup` | Enable logical backup for Zalando postgres databases (SQL commands with pg_dump) | `true` |
+| `opmet.db.cleanInstall` | Create a clean Zalando postgres database (turning `false` will enable cloning startup state from backup, database won't start if no backup found) | `true` |
+| `opmet.db.backupBucket` | AWS S3 bucket used to fetch database backup | |
+| `opmet.db.backupTimestamp` | Timestamp to fetch database backup from (latest backup before configured timestamp) | `"2030-01-01T00:00:00+00:00"` |
+| `opmet.db.name` | Default postgres database container/Zalando postgres database pod name | `opmet-db` |
 | `opmet.db.image` | Default postgres database image | `postgres` |
 | `opmet.db.port` | Default postgres database port | `5432` |
-| `opmet.db.POSTGRES_DB` | Default postgres database name | `opmet` |
-| `opmet.db.POSTGRES_USER` | Default postgres database user | `postgres` |
+| `opmet.db.POSTGRES_DB` | Default/Zalando postgres database name | `opmet` |
+| `opmet.db.POSTGRES_USER` | Default/Zalando postgres database user | `geoweb` |
 | `opmet.db.POSTGRES_PASSWORD` | Default postgres database password | `postgres` |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |
 | `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | `nginx` |

--- a/charts/geoweb-opmet-backend/templates/opmet-database.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-database.yaml
@@ -1,0 +1,22 @@
+apiVersion: "acid.zalan.do/v1"
+kind: postgresql
+metadata:
+  name: opmet-db
+spec:
+  teamId: fmi
+  volume:
+    size: 1Gi
+  numberOfInstances: 2
+  users:
+    geoweb:
+    - superuser
+    - createdb
+  databases:
+    opmet: geoweb
+  postgresql:
+    version: "15"
+  enableLogicalBackup: true
+  clone:
+    cluster: "opmet-db"
+    timestamp: "2024-10-24T11:40:00+00:00"
+    s3_wal_path: "s3://<s3-bucket>/spilo/opmet-db/wal/15"

--- a/charts/geoweb-opmet-backend/templates/opmet-database.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-database.yaml
@@ -1,22 +1,24 @@
+{{- if .Values.opmet.db.useZalandoOperatorDb }}
 apiVersion: "acid.zalan.do/v1"
 kind: postgresql
 metadata:
-  name: opmet-db
+  name: {{ .Values.opmet.db.name }}
 spec:
-  teamId: fmi
+  teamId: {{ .Values.opmet.db.zalandoTeamId }}
   volume:
-    size: 1Gi
-  numberOfInstances: 1
+    size: {{ .Values.opmet.db.instanceSize }}
+  numberOfInstances: {{ .Values.opmet.db.numberOfInstances }}
   users:
-    geoweb:
+    {{ .Values.opmet.db.POSTGRES_USER }}:
     - superuser
     - createdb
   databases:
-    opmet: geoweb
+    {{ .Values.opmet.db.POSTGRES_DB }}: {{ .Values.opmet.db.POSTGRES_USER }}
   postgresql:
-    version: "15"
-  enableLogicalBackup: true
+    version: {{ .Values.opmet.db.POSTGRES_VERSION | quote }}
+  enableLogicalBackup: {{ .Values.opmet.db.enableLogicalBackup }}
   clone:
-    cluster: "opmet-db"
-    timestamp: "2030-01-01T00:00:00+00:00"
-    s3_wal_path: "s3://<s3-bucket>/"
+    cluster: {{ .Values.opmet.db.name | quote }}
+    timestamp: {{ .Values.opmet.db.backupTimestamp | quote }}
+    s3_wal_path: {{ .Values.opmet.db.backupBucket | quote }}
+{{- end }}

--- a/charts/geoweb-opmet-backend/templates/opmet-database.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-database.yaml
@@ -6,7 +6,7 @@ spec:
   teamId: fmi
   volume:
     size: 1Gi
-  numberOfInstances: 2
+  numberOfInstances: 1
   users:
     geoweb:
     - superuser
@@ -18,5 +18,5 @@ spec:
   enableLogicalBackup: true
   clone:
     cluster: "opmet-db"
-    timestamp: "2024-10-24T11:40:00+00:00"
-    s3_wal_path: "s3://<s3-bucket>/spilo/opmet-db/wal/15"
+    timestamp: "2030-01-01T00:00:00+00:00"
+    s3_wal_path: "s3://<s3-bucket>/"

--- a/charts/geoweb-opmet-backend/templates/opmet-database.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-database.yaml
@@ -17,8 +17,10 @@ spec:
   postgresql:
     version: {{ .Values.opmet.db.POSTGRES_VERSION | quote }}
   enableLogicalBackup: {{ .Values.opmet.db.enableLogicalBackup }}
+  {{- if not .Values.opmet.db.cleanInstall }}
   clone:
     cluster: {{ .Values.opmet.db.name | quote }}
     timestamp: {{ .Values.opmet.db.backupTimestamp | quote }}
     s3_wal_path: {{ .Values.opmet.db.backupBucket | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
@@ -53,12 +53,14 @@ spec:
             secretKeyRef:
               name: geoweb.opmet-db.credentials.postgresql.acid.zalan.do
               key: username
+        - name: SQLALCHEMY_DATABASE_URL
+          value: "postgresql://$(PG_USER):$(PG_PASS)@opmet-db:5432/opmet"
         volumeMounts:
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
           readOnly: true
         command: ["/bin/sh"]
-        args: ["-c", "sleep 30; export SQLALCHEMY_DATABASE_URL='postgresql://$(PG_USER):$(PG_PASS)@opmet-db:5432/opmet'; gunicorn --bind 0.0.0.0:8000 -k uvicorn.workers.UvicornWorker --log-config opmet_logging.conf opmet_backend.main:app"]
+        args: ["-c", "sleep 10; gunicorn --bind 0.0.0.0:8000 -k uvicorn.workers.UvicornWorker --log-config opmet_logging.conf opmet_backend.main:app"]
       - name: {{ .Values.opmet.messageconverter.name }}
         image: {{ .Values.opmet.messageconverter.registry }}:{{ .Values.opmet.messageconverter.version }}
       {{- if .Values.opmet.imagePullPolicy }}

--- a/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
@@ -73,7 +73,7 @@ spec:
       {{- end }}
         - name: SQLALCHEMY_DATABASE_URL
         {{- if .Values.opmet.db.useZalandoOperatorDb }}
-          value: "postgresql://$(PG_USER):$(PG_PASS)@opmet-db:5432/opmet"
+          value: "postgresql://$(PG_USER):$(PG_PASS)@{{ .Values.opmet.db.name }}:5432/{{ .Values.opmet.db.POSTGRES_DB }}"
         {{- else }}
           valueFrom:
             secretKeyRef:
@@ -91,7 +91,7 @@ spec:
           name: {{ .Values.opmet.name }}-volume
       {{- end }}
         command: ["/bin/sh"]
-        args: ["-c", "sleep 10; gunicorn --bind 0.0.0.0:8000 -k uvicorn.workers.UvicornWorker --log-config opmet_logging.conf opmet_backend.main:app"]
+        args: ["-c", "sleep 10 ; gunicorn --bind 0.0.0.0:8000 -k uvicorn.workers.UvicornWorker --log-config opmet_logging.conf opmet_backend.main:app"]
       - name: {{ .Values.opmet.messageconverter.name }}
         image: {{ .Values.opmet.messageconverter.registry }}:{{ .Values.opmet.messageconverter.version }}
       {{- if .Values.opmet.imagePullPolicy }}

--- a/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
@@ -43,17 +43,22 @@ spec:
         - configMapRef:
             name: {{ .Values.opmet.name }}
         env:
-        - name: SQLALCHEMY_DATABASE_URL
+        - name: PG_PASS
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.opmet.db_secretName }}
-              key: OPMET_BACKEND_DB
+              name: geoweb.opmet-db.credentials.postgresql.acid.zalan.do
+              key: password
+        - name: PG_USER
+          valueFrom:
+            secretKeyRef:
+              name: geoweb.opmet-db.credentials.postgresql.acid.zalan.do
+              key: username
         volumeMounts:
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
           readOnly: true
         command: ["/bin/sh"]
-        args: ["-c", "sleep 10 ; gunicorn --bind 0.0.0.0:8000 -k uvicorn.workers.UvicornWorker --log-config opmet_logging.conf opmet_backend.main:app"]
+        args: ["-c", "sleep 30; export SQLALCHEMY_DATABASE_URL='postgresql://$(PG_USER):$(PG_PASS)@opmet-db:5432/opmet'; gunicorn --bind 0.0.0.0:8000 -k uvicorn.workers.UvicornWorker --log-config opmet_logging.conf opmet_backend.main:app"]
       - name: {{ .Values.opmet.messageconverter.name }}
         image: {{ .Values.opmet.messageconverter.registry }}:{{ .Values.opmet.messageconverter.version }}
       {{- if .Values.opmet.imagePullPolicy }}

--- a/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
@@ -59,6 +59,7 @@ spec:
         - configMapRef:
             name: {{ .Values.opmet.name }}
         env:
+      {{- if .Values.opmet.db.useZalandoOperatorDb }}
         - name: PG_PASS
           valueFrom:
             secretKeyRef:
@@ -69,12 +70,22 @@ spec:
             secretKeyRef:
               name: geoweb.opmet-db.credentials.postgresql.acid.zalan.do
               key: username
+      {{- end }}
         - name: SQLALCHEMY_DATABASE_URL
+        {{- if .Values.opmet.db.useZalandoOperatorDb }}
           value: "postgresql://$(PG_USER):$(PG_PASS)@opmet-db:5432/opmet"
+        {{- else }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.opmet.db_secretName }}
+              key: OPMET_BACKEND_DB
+        {{- end }}
         volumeMounts:
+      {{- if not .Values.opmet.db.useZalandoOperatorDb }}
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
           readOnly: true
+      {{- end }}
       {{- if and .Values.opmet.useCustomConfigurationFiles }}
         - mountPath: {{ .Values.opmet.customConfigurationMountPath }}
           name: {{ .Values.opmet.name }}-volume
@@ -164,6 +175,7 @@ spec:
           claimName: {{ .Values.opmet.name }}-claim
       {{- end }}
     {{- end }}
+    {{- if not .Values.opmet.db.useZalandoOperatorDb }}
       - name: secrets-store-inline
       {{- if .Values.secretProvider }}
         csi:
@@ -175,6 +187,7 @@ spec:
         secret:
           secretName: {{ .Values.opmet.db_secretName | quote }}
       {{- end }}
+    {{- end }}
       - name: publisher-volume
       {{- if .Values.opmet.publisher.volumeOptions }}
         {{- toYaml .Values.opmet.publisher.volumeOptions | nindent 8 }}

--- a/charts/geoweb-opmet-backend/templates/opmet-secrets.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-secrets.yaml
@@ -29,7 +29,7 @@ spec:
       objectName: {{ .Values.opmet.db_secret }}
     secretName: {{ .Values.opmet.db_secretName }}
     type: Opaque
-{{- else }}
+{{- else if not .Values.opmet.db.useZalandoOperatorDb }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/geoweb-opmet-backend/values.yaml
+++ b/charts/geoweb-opmet-backend/values.yaml
@@ -134,6 +134,8 @@ opmet:
     instanceSize: 100Mi
     zalandoTeamId: geoweb
     enableLogicalBackup: true
+    cleanInstall: true
+    backupTimestamp: "2030-01-01T00:00:00+00:00"
   useCustomConfigurationFiles: false
   customConfigurationLocation: local
   customConfigurationMountPath: /app/configuration_files/custom

--- a/charts/geoweb-opmet-backend/values.yaml
+++ b/charts/geoweb-opmet-backend/values.yaml
@@ -7,7 +7,7 @@ opmet:
   path: /opmet/(.*)
   svcPort: 80
   replicas: 1
-  db_secret: cG9zdGdyZXNxbDovL3Bvc3RncmVzOnBvc3RncmVzQGxvY2FsaG9zdDo1NDMyL29wbWV0
+  db_secret: cG9zdGdyZXNxbDovL2dlb3dlYjpwb3N0Z3Jlc0Bsb2NhbGhvc3Q6NTQzMi9vcG1ldA==
   db_secretName: opmet-db
   db_secretType: secretsmanager
   spcName: opmet-spc
@@ -122,12 +122,18 @@ opmet:
       failureThreshold: 1
   db:
     enableDefaultDb: true
-    name: postgres
+    useZalandoOperatorDb: false
+    name: opmet-db
     image: postgres
     port: 5432
     POSTGRES_DB: opmet
-    POSTGRES_USER: postgres
+    POSTGRES_USER: geoweb
     POSTGRES_PASSWORD: postgres
+    POSTGRES_VERSION: 15
+    numberOfInstances: 1
+    instanceSize: 100Mi
+    zalandoTeamId: geoweb
+    enableLogicalBackup: true
   useCustomConfigurationFiles: false
   customConfigurationLocation: local
   customConfigurationMountPath: /app/configuration_files/custom

--- a/charts/geoweb-opmet-backend/values.yaml
+++ b/charts/geoweb-opmet-backend/values.yaml
@@ -128,6 +128,7 @@ opmet:
     POSTGRES_DB: opmet
     POSTGRES_USER: postgres
     POSTGRES_PASSWORD: postgres
+
 ingress:
   name: nginx-ingress-controller
   ingressClassName: nginx


### PR DESCRIPTION
Added option to use Zalando Operator Postgres database instead of connection string to external database
* If useZalandoOperatorDb == true
  * Add postgresql resource
  * Use generated username & password created by postgresql resource to automatically set SQLALCHEMY_DATABASE_URL instead of using db_secret
  * Don't generate db secret using db_secret
* If useZalandoOperatorDb == false
  * No changes except for changed default database name (and encoded database string)
* cleanInstall determines if database is started clean or restored from a backup

* Updated chart testing action to fix validation error

How to test: Code review & inspect test deployment running in test-geoweb cluster, accessible at https://terraform.opengeoweb.com/opmet

Test cluster is running with configurations created in this PR: https://github.com/fmidev/terraform-aws-geoweb/pull/4

Closes https://gitlab.com/opengeoweb/fmi/fmi-aws-config/-/issues/119