### PR TITLE
Add SFTP publisher support to geoweb-opmet-backend

### DIFF
--- a/charts/geoweb-opmet-backend/Chart.yaml
+++ b/charts/geoweb-opmet-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0
+version: 2.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-opmet-backend/README.md
+++ b/charts/geoweb-opmet-backend/README.md
@@ -183,6 +183,7 @@ The following table lists the configurable parameters of the Opmet backend chart
 | `opmet.publisher.TIMEOUT_SECONDS` | Timeout when trying to connect to SFTP server | |
 | `opmet.publisher.USE_TEMP_FILE` | Use temp file before publishing file to SFTP server | |
 | `opmet.publisher.TEMP_FILE_SUFFIX` | Suffix used for the temp file | |
+| `opmet.publisher.S3_BUCKET_NAME` | S3 Bucket used to publish files to | |
 | `opmet.publisher.volumeOptions` | yaml including the definition of the volume where TACs are published to, for example: <pre>hostPath:<br>&nbsp;&nbsp; path: /test/path</pre> or <pre>emptyDir:<br>&nbsp;&nbsp;</pre>| `emptyDir:` |
 | `opmet.publisher.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `opmet.publisher.livenessProbe` | Configure libenessProbe | see defaults from `values.yaml` |

--- a/charts/geoweb-opmet-backend/README.md
+++ b/charts/geoweb-opmet-backend/README.md
@@ -8,11 +8,13 @@ helm repo update
 # Create requried dependencies
 
 Create values.yaml file for required variables:
-* Using aws as the secret provider
+* Using aws as the secret provider (use any mix of db_secret, ssh_secret and ssh_secret_passphrase)
 ```yaml
 opmet: 
   url: geoweb.example.com
-  db_secret: secretName # Secret should contain postgresql database connection string
+  db_secret: secretName
+  ssh_secret: secretName
+  ssh_secret_passphrase: secretName
   iamRoleARN: arn:aws:iam::123456789012:role/example-iam-role-with-permissions-to-secret
 
 secretProvider: aws
@@ -20,11 +22,13 @@ secretProviderParameters:
   region: your-region
 ```
 
-* Using base64 encoded secret
+* Using base64 encoded secret (use any mix of db_secret, ssh_secret and ssh_secret_passphrase)
 ```yaml
 opmet:
   url: geoweb.example.com
   db_secret: base64_encoded_postgresql_connection_string
+  ssh_secret: base64_encoded_ssh_private_key
+  ssh_secret_passphrase: base64_encoded_ssh_private_key_passphrase
 ```
 
 * Using custom configuration files stored locally
@@ -111,6 +115,16 @@ The following table lists the configurable parameters of the Opmet backend chart
 | `opmet.db_secretType` | Type to db secret | `secretsmanager` |
 | `opmet.db_secretPath` | Path to db secret | |
 | `opmet.db_secretKey` | Key of db secret | |
+| `opmet.ssh_secret` | Secret containing base64 encoded SSH private key | |
+| `opmet.ssh_secretName` | Name of db secret | `opmet-publisher-ssh-key` |
+| `opmet.ssh_secretType` | Type to db secret | `secretsmanager` |
+| `opmet.ssh_secretPath` | Path to db secret | |
+| `opmet.ssh_secretKey` | Key of db secret | |
+| `opmet.ssh_passphrase_secret` | Secret containing base64 encoded SSH private key passphrase | |
+| `opmet.ssh_passphrase_secretName` | Name of db secret | `opmet-publisher-ssh-passphrase` |
+| `opmet.ssh_passphrase_secretType` | Type to db secret | `secretsmanager` |
+| `opmet.ssh_passphrase_secretPath` | Path to db secret | |
+| `opmet.ssh_passphrase_secretKey` | Key of db secret | |
 | `opmet.iamRoleARN` | IAM Role with permissions to access db_secret secret | |
 | `opmet.secretServiceAccount` | Service Account created for handling secrets | `opmet-service-account` |
 | `opmet.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
@@ -158,7 +172,17 @@ The following table lists the configurable parameters of the Opmet backend chart
 | `opmet.publisher.name` | Name of publisher container  | `opmet-publisher` |
 | `opmet.publisher.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/backend-services/opmet-backend/opmet-backend-publisher-local` |
 | `opmet.publisher.port` | Port used for publisher | `8090`|
-| `opmet.publisher.DESTINATION` | Folder inside publisher container where TACs are stored | `/app/output` |
+| `opmet.publisher.DESTINATION` | Folder inside publisher container where TACs are stored (used with local-publisher) | `/app/output` |
+| `opmet.publisher.USERNAME` | Username used to access SFTP server | |
+| `opmet.publisher.PASSWORD` | Password used to access SFTP server (Empty if using SSH authentication) | |
+| `opmet.publisher.PRIVATE_KEY_BASE_PATH` | Path to SSH key used to access SFTP server (Empty if using password authentication), gets combined to PRIVATE_KEY_PATH environment variable with ssh_secret added as filename | `/mnt/secrets-store/` |
+| `opmet.publisher.PRIVATE_KEY_PASSPHRASE` | SSH passphrase used for the SSH key (Empty if using password authentication)| |
+| `opmet.publisher.HOSTNAME` | Hostname of used SFTP server | |
+| `opmet.publisher.PORT` | Port used to connect to SFTP server | |
+| `opmet.publisher.REMOTE_DIR` | Folder used in the SFTP server | |
+| `opmet.publisher.TIMEOUT_SECONDS` | Timeout when trying to connect to SFTP server | |
+| `opmet.publisher.USE_TEMP_FILE` | Use temp file before publishing file to SFTP server | |
+| `opmet.publisher.TEMP_FILE_SUFFIX` | Suffix used for the temp file | |
 | `opmet.publisher.volumeOptions` | yaml including the definition of the volume where TACs are published to, for example: <pre>hostPath:<br>&nbsp;&nbsp; path: /test/path</pre> or <pre>emptyDir:<br>&nbsp;&nbsp;</pre>| `emptyDir:` |
 | `opmet.publisher.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `opmet.publisher.livenessProbe` | Configure libenessProbe | see defaults from `values.yaml` |

--- a/charts/geoweb-opmet-backend/README.md
+++ b/charts/geoweb-opmet-backend/README.md
@@ -116,16 +116,16 @@ The following table lists the configurable parameters of the Opmet backend chart
 | `opmet.db_secretPath` | Path to db secret | |
 | `opmet.db_secretKey` | Key of db secret | |
 | `opmet.ssh_secret` | Secret containing base64 encoded SSH private key | |
-| `opmet.ssh_secretName` | Name of db secret | `opmet-publisher-ssh-key` |
-| `opmet.ssh_secretType` | Type to db secret | `secretsmanager` |
-| `opmet.ssh_secretPath` | Path to db secret | |
-| `opmet.ssh_secretKey` | Key of db secret | |
+| `opmet.ssh_secretName` | Name of ssh key secret | `opmet-publisher-ssh-key` |
+| `opmet.ssh_secretType` | Type to ssh key secret | `secretsmanager` |
+| `opmet.ssh_secretPath` | Path to ssh key secret | |
+| `opmet.ssh_secretKey` | Key of ssh key secret | |
 | `opmet.ssh_passphrase_secret` | Secret containing base64 encoded SSH private key passphrase | |
-| `opmet.ssh_passphrase_secretName` | Name of db secret | `opmet-publisher-ssh-passphrase` |
-| `opmet.ssh_passphrase_secretType` | Type to db secret | `secretsmanager` |
-| `opmet.ssh_passphrase_secretPath` | Path to db secret | |
-| `opmet.ssh_passphrase_secretKey` | Key of db secret | |
-| `opmet.iamRoleARN` | IAM Role with permissions to access db_secret secret | |
+| `opmet.ssh_passphrase_secretName` | Name of ssh passphrase secret | `opmet-publisher-ssh-passphrase` |
+| `opmet.ssh_passphrase_secretType` | Type to ssh passphrase secret | `secretsmanager` |
+| `opmet.ssh_passphrase_secretPath` | Path to ssh passphrase secret | |
+| `opmet.ssh_passphrase_secretKey` | Key of ssh passphrase secret | |
+| `opmet.iamRoleARN` | IAM Role with permissions to access secrets | |
 | `opmet.secretServiceAccount` | Service Account created for handling secrets | `opmet-service-account` |
 | `opmet.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `opmet.livenessProbe` | Configure libenessProbe | see defaults from `values.yaml` |
@@ -147,7 +147,7 @@ The following table lists the configurable parameters of the Opmet backend chart
 | `opmet.volumeAccessMode` | Permissions of the application for the custom configurations PersistentVolume used | `ReadOnlyMany` |
 | `opmet.volumeSize` | Size of the custom configurations PersistentVolume | `100Mi` |
 | `opmet.customConfigurationFolderPath` | Path to the folder which contains custom configurations | |
-| `opmet.customConfigurationMountPath` | Folder used to mount custom configurations | `/app/custom` |
+| `opmet.customConfigurationMountPath` | Folder used to mount custom configurations | `/app/configuration_files/custom` |
 | `opmet.s3bucketName` | Name of the S3 bucket where custom configurations are stored | |
 | `opmet.awsAccessKeyId` | AWS_ACCESS_KEY_ID for authenticating to S3 | |
 | `opmet.awsAccessKeySecret` | AWS_SECRET_ACCESS_KEY for authenticating to S3 | |

--- a/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     {{- if eq .Values.secretProvider "aws" }}
       serviceAccountName: {{ .Values.opmet.secretServiceAccount }}
     {{- end }}
-        {{- if and .Values.opmet.useCustomConfigurationFiles (eq .Values.opmet.customConfigurationLocation "s3")}}
+    {{- if and .Values.opmet.useCustomConfigurationFiles (eq .Values.opmet.customConfigurationLocation "s3")}}
       initContainers:
       - name: init
         image: amazon/aws-cli
@@ -130,7 +130,20 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ .Values.opmet.publisher.name }}
+      {{- if .Values.opmet.ssh_passphrase_secret }}
+        env:
+        - name: PRIVATE_KEY_PASSPHRASE
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.opmet.ssh_passphrase_secretName }}
+              key: SSH_KEY_PASSPHRASE
+      {{- end }}
         volumeMounts:
+      {{- if .Values.opmet.ssh_secret }}
+        - name: secrets-store-inline
+          mountPath: "/mnt/secrets-store"
+          readOnly: true
+      {{- end }}
         - name: publisher-volume
           mountPath: {{ .Values.opmet.publisher.DESTINATION | quote }}
       - name: {{ .Values.opmet.nginx.name }}
@@ -184,8 +197,20 @@ spec:
           volumeAttributes:
             secretProviderClass: {{ .Values.opmet.spcName | quote }}
       {{- else }}
-        secret:
-          secretName: {{ .Values.opmet.db_secretName | quote }}
+        projected:
+          sources:
+          {{- if and .Values.opmet.db_secret (not .Values.opmet.db.useZalandoOperatorDb) }}
+          - secret:
+              name: {{ .Values.opmet.db_secretName }}
+          {{- end }}
+          {{- if .Values.opmet.ssh_secret }}
+          - secret:
+              name: {{ .Values.opmet.ssh_secretName }}
+          {{- end }}
+          {{- if .Values.opmet.ssh_passphrase_secret }}
+          - secret:
+              name: {{ .Values.opmet.ssh_passphrase_secretName }}
+          {{- end }}
       {{- end }}
     {{- end }}
       - name: publisher-volume

--- a/charts/geoweb-opmet-backend/templates/opmet-publisher-configmap.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-publisher-configmap.yaml
@@ -40,3 +40,6 @@ data:
 {{- if .Values.opmet.publisher.TEMP_FILE_SUFFIX }}
   TEMP_FILE_SUFFIX: {{ .Values.opmet.publisher.TEMP_FILE_SUFFIX | quote }}
 {{- end }}
+{{- if .Values.opmet.publisher.S3_BUCKET_NAME }}
+  S3_BUCKET_NAME: {{ .Values.opmet.publisher.S3_BUCKET_NAME | quote }}
+{{- end }}

--- a/charts/geoweb-opmet-backend/templates/opmet-publisher-configmap.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-publisher-configmap.yaml
@@ -16,8 +16,8 @@ data:
 {{- if .Values.opmet.publisher.PASSWORD }}
   PASSWORD: {{ .Values.opmet.publisher.PASSWORD | quote }}
 {{- end }}
-{{- if .Values.opmet.publisher.PRIVATE_KEY_PATH }}
-  PRIVATE_KEY_PATH: {{ .Values.opmet.publisher.PRIVATE_KEY_PATH | quote }}
+{{- if and .Values.opmet.publisher.PRIVATE_KEY_BASE_PATH .Values.opmet.ssh_secret }}
+  PRIVATE_KEY_PATH: "{{ .Values.opmet.publisher.PRIVATE_KEY_BASE_PATH }}{{ .Values.opmet.ssh_secret }}"
 {{- end }}
 {{- if .Values.opmet.publisher.PRIVATE_KEY_PASSPHRASE }}
   PRIVATE_KEY_PASSPHRASE: {{ .Values.opmet.publisher.PRIVATE_KEY_PASSPHRASE | quote }}

--- a/charts/geoweb-opmet-backend/templates/opmet-publisher-configmap.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-publisher-configmap.yaml
@@ -7,4 +7,36 @@ metadata:
     commitHash: {{ .Values.opmet.commitHash }}
   {{- end }}
 data:
+{{- if .Values.opmet.publisher.DESTINATION }}
   DESTINATION: {{ .Values.opmet.publisher.DESTINATION | quote }}
+{{- end }}
+{{- if .Values.opmet.publisher.USERNAME }}
+  USERNAME: {{ .Values.opmet.publisher.USERNAME | quote }}
+{{- end }}
+{{- if .Values.opmet.publisher.PASSWORD }}
+  PASSWORD: {{ .Values.opmet.publisher.PASSWORD | quote }}
+{{- end }}
+{{- if .Values.opmet.publisher.PRIVATE_KEY_PATH }}
+  PRIVATE_KEY_PATH: {{ .Values.opmet.publisher.PRIVATE_KEY_PATH | quote }}
+{{- end }}
+{{- if .Values.opmet.publisher.PRIVATE_KEY_PASSPHRASE }}
+  PRIVATE_KEY_PASSPHRASE: {{ .Values.opmet.publisher.PRIVATE_KEY_PASSPHRASE | quote }}
+{{- end }}
+{{- if .Values.opmet.publisher.HOSTNAME }}
+  HOSTNAME: {{ .Values.opmet.publisher.HOSTNAME | quote }}
+{{- end }}
+{{- if .Values.opmet.publisher.PORT }}
+  PORT: {{ .Values.opmet.publisher.PORT | quote }}
+{{- end }}
+{{- if .Values.opmet.publisher.REMOTE_DIR }}
+  REMOTE_DIR: {{ .Values.opmet.publisher.REMOTE_DIR | quote }}
+{{- end }}
+{{- if .Values.opmet.publisher.TIMEOUT_SECONDS }}
+  TIMEOUT_SECONDS: {{ .Values.opmet.publisher.TIMEOUT_SECONDS | quote }}
+{{- end }}
+{{- if .Values.opmet.publisher.USE_TEMP_FILE }}
+  USE_TEMP_FILE: {{ .Values.opmet.publisher.USE_TEMP_FILE | quote }}
+{{- end }}
+{{- if .Values.opmet.publisher.TEMP_FILE_SUFFIX }}
+  TEMP_FILE_SUFFIX: {{ .Values.opmet.publisher.TEMP_FILE_SUFFIX | quote }}
+{{- end }}

--- a/charts/geoweb-opmet-backend/templates/opmet-secrets.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-secrets.yaml
@@ -8,32 +8,101 @@ spec:
   parameters:
   {{- if or (eq .Values.secretProvider "aws") (eq .Values.secretProvider "azure") }}
     objects: |
+    {{- if and .Values.opmet.db_secret (not .Values.opmet.db.useZalandoOperatorDb) }}
       - objectName: {{ .Values.opmet.db_secret | quote }}
         objectType: {{ .Values.opmet.db_secretType | quote }}
+    {{- end }}
+    {{- if .Values.opmet.ssh_secret }}
+      - objectName: {{ .Values.opmet.ssh_secret | quote }}
+        objectType: {{ .Values.opmet.ssh_secretType | quote }}
+    {{- end }}
+    {{- if .Values.opmet.ssh_passphrase_secret }}
+      - objectName: {{ .Values.opmet.ssh_passphrase_secret | quote }}
+        objectType: {{ .Values.opmet.ssh_passphrase_secretType | quote }}
+    {{- end }}
   {{- else if eq .Values.secretProvider "gcp" }}
     secrets: |
+    {{- if and .Values.opmet.db_secret (not .Values.opmet.db.useZalandoOperatorDb) }}
       - resourceName: {{ .Values.opmet.db_secret | quote }}
         path: {{ .Values.opmet.db_secretPath | quote }}
+    {{- end }}
+    {{- if .Values.opmet.ssh_secret }}
+      - resourceName: {{ .Values.opmet.ssh_secret | quote }}
+        path: {{ .Values.opmet.ssh_secretPath | quote }}
+    {{- end }}
+    {{- if .Values.opmet.ssh_passphrase_secret }}
+      - resourceName: {{ .Values.opmet.ssh_passphrase_secret | quote }}
+        path: {{ .Values.opmet.ssh_passphrase_secretPath | quote }}
+    {{- end }}
   {{- else if eq .Values.secretProvider "vault" }}
     objects: |
+    {{- if and .Values.opmet.db_secret (not .Values.opmet.db.useZalandoOperatorDb) }}
       - objectName: {{ .Values.opmet.db_secret | quote }}
         secretPath: {{ .Values.opmet.db_secretPath | quote }}
         secretKey: {{ .Values.opmet.db_secretKey | quote }}
+    {{- end }}
+    {{- if .Values.opmet.ssh_secret }}
+      - objectName: {{ .Values.opmet.ssh_secret | quote }}
+        secretPath: {{ .Values.opmet.ssh_secretPath | quote }}
+        secretKey: {{ .Values.opmet.ssh_secretKey | quote }}
+    {{- end }}
+    {{- if .Values.opmet.ssh_passphrase_secret }}
+      - objectName: {{ .Values.opmet.ssh_passphrase_secret | quote }}
+        secretPath: {{ .Values.opmet.ssh_passphrase_secretPath | quote }}
+        secretKey: {{ .Values.opmet.ssh_passphrase_secretKey | quote }}
+    {{- end }}
   {{- end }}
   {{- range $key, $value := .Values.secretProviderParameters }}
     {{ $key }}: {{ $value }}
   {{- end }}
   secretObjects: # Creates kubernetes secret objects
+  {{- if and .Values.opmet.db_secret (not .Values.opmet.db.useZalandoOperatorDb) }}
   - data:
     - key: OPMET_BACKEND_DB
       objectName: {{ .Values.opmet.db_secret }}
     secretName: {{ .Values.opmet.db_secretName }}
     type: Opaque
-{{- else if not .Values.opmet.db.useZalandoOperatorDb }}
+  {{- end }}
+  {{- if .Values.opmet.ssh_secret }}
+  - data:
+    - key: ssh-privatekey
+      objectName: {{ .Values.opmet.ssh_secret }}
+    secretName: {{ .Values.opmet.ssh_secretName }}
+    type: kubernetes.io/ssh-auth
+  {{- end }}
+  {{- if .Values.opmet.ssh_passphrase_secret }}
+  - data:
+    - key: SSH_KEY_PASSPHRASE
+      objectName: {{ .Values.opmet.ssh_passphrase_secret }}
+    secretName: {{ .Values.opmet.ssh_passphrase_secretName }}
+    type: Opaque
+  {{- end }}
+{{- else }}
+{{- if and .Values.opmet.db_secret (not .Values.opmet.db.useZalandoOperatorDb) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.opmet.db_secretName }}
 data:
   OPMET_BACKEND_DB: {{ .Values.opmet.db_secret }}
+{{- end }}
+{{- if .Values.opmet.ssh_secret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.opmet.ssh_passphrase_secretName }}
+data:
+  SSH_KEY_PASSPHRASE: {{ .Values.opmet.ssh_passphrase_secret }}
+{{- end }}
+{{- if .Values.opmet.ssh_passphrase_secret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.opmet.ssh_secretName }}
+type: kubernetes.io/ssh-auth
+data:
+  ssh-privatekey: {{ .Values.opmet.ssh_secret }}
+{{- end }}
 {{- end }}

--- a/charts/geoweb-opmet-backend/values.yaml
+++ b/charts/geoweb-opmet-backend/values.yaml
@@ -47,7 +47,7 @@ opmet:
   messageconverter:
     name: opmet-messageconverter
     registry: registry.gitlab.com/opengeoweb/avi-msgconverter/geoweb-knmi-avi-messageservices
-    version: "0.1.1"
+    version: "0.2.0"
     port: 8080
     resources:
       requests:
@@ -75,7 +75,7 @@ opmet:
     registry: registry.gitlab.com/opengeoweb/backend-services/opmet-backend/opmet-backend-publisher-local
     port: 8090
     DESTINATION: /app/output
-    PRIVATE_KEY_PATH: /mnt/secrets-store/opmet-publisher-ssh-key
+    PRIVATE_KEY_BASE_PATH: /mnt/secrets-store/
     resources:
       requests:
         memory: "50Mi"

--- a/charts/geoweb-opmet-backend/values.yaml
+++ b/charts/geoweb-opmet-backend/values.yaml
@@ -10,6 +10,10 @@ opmet:
   db_secret: cG9zdGdyZXNxbDovL2dlb3dlYjpwb3N0Z3Jlc0Bsb2NhbGhvc3Q6NTQzMi9vcG1ldA==
   db_secretName: opmet-db
   db_secretType: secretsmanager
+  ssh_secretName: opmet-publisher-ssh-key
+  ssh_secretType: secretsmanager
+  ssh_passphrase_secretName: opmet-publisher-ssh-passphrase
+  ssh_passphrase_secretType: secretsmanager
   spcName: opmet-spc
   secretServiceAccount: opmet-service-account
   resources:
@@ -71,6 +75,7 @@ opmet:
     registry: registry.gitlab.com/opengeoweb/backend-services/opmet-backend/opmet-backend-publisher-local
     port: 8090
     DESTINATION: /app/output
+    PRIVATE_KEY_PATH: /mnt/secrets-store/opmet-publisher-ssh-key
     resources:
       requests:
         memory: "50Mi"


### PR DESCRIPTION
* Added all possible environment variables for SFTP (and S3) publishers
  * SSH key and passphrase as secrets and others via configmap
* Updated messageservices default version to v0.2.0

How to test:
* FMI ACC has opmet-backend version enabled that uses the new SFTP publisher, it can be verified to work there
* Otherwise code review enough & optionally you could run own SFTP server locally and configure opmet to send TAC/IWXXMs there