### PR TITLE
Make all geoweb-opmet-backend config map values optional

### DIFF
--- a/charts/geoweb-opmet-backend/Chart.yaml
+++ b/charts/geoweb-opmet-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.0
+version: 2.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-opmet-backend/templates/opmet-configmap.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-configmap.yaml
@@ -7,13 +7,33 @@ metadata:
     commitHash: {{ .Values.opmet.commitHash }}
   {{- end }}
 data:
+{{- if .Values.opmet.env.MESSAGECONVERTER_URL }}
   MESSAGECONVERTER_URL: {{ .Values.opmet.env.MESSAGECONVERTER_URL | quote }}
+{{- end }}
+{{- if .Values.opmet.env.OAUTH2_USERINFO }}
   OAUTH2_USERINFO: {{ .Values.opmet.env.OAUTH2_USERINFO | quote }}
+{{- end }}
+{{- if .Values.opmet.env.OPMET_BACKEND_PORT_HTTP }}
   OPMET_BACKEND_PORT_HTTP: {{ .Values.opmet.env.OPMET_BACKEND_PORT_HTTP | quote }}
+{{- end }}
+{{- if .Values.opmet.env.EXTERNALADDRESSES }}
   EXTERNALADDRESSES: {{ .Values.opmet.env.EXTERNALADDRESSES | quote }}
+{{- end }}
+{{- if .Values.opmet.env.OPMET_ENABLE_SSL }}
   OPMET_ENABLE_SSL: {{ .Values.opmet.env.OPMET_ENABLE_SSL | quote }}
+{{- end }}
+{{- if .Values.opmet.env.FORWARDED_ALLOW_IPS }}
   FORWARDED_ALLOW_IPS: {{ .Values.opmet.env.FORWARDED_ALLOW_IPS | quote }}
+{{- end }}
+{{- if .Values.opmet.env.PUBLISHER_URL }}
   PUBLISHER_URL: {{ .Values.opmet.env.PUBLISHER_URL | quote }}
+{{- end }}
+{{- if .Values.opmet.env.BACKEND_CONFIG }}
   BACKEND_CONFIG: {{ .Values.opmet.env.BACKEND_CONFIG | quote }}
+{{- end }}
+{{- if .Values.opmet.env.SIGMET_CONFIG }}
   SIGMET_CONFIG: {{ .Values.opmet.env.SIGMET_CONFIG | quote }}
+{{- end }}
+{{- if .Values.opmet.env.AIRMET_CONFIG }}
   AIRMET_CONFIG: {{ .Values.opmet.env.AIRMET_CONFIG | quote }}
+{{- end }}

--- a/charts/geoweb-opmet-backend/templates/opmet-nginx-configmap.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-nginx-configmap.yaml
@@ -3,8 +3,18 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.opmet.nginx.name }}
 data:
+{{- if .Values.opmet.nginx.OPMET_ENABLE_SSL }}
   OPMET_ENABLE_SSL: {{ .Values.opmet.nginx.OPMET_ENABLE_SSL | quote }}
+{{- end}}
+{{- if .Values.opmet.nginx.EXTERNAL_HOSTNAME }}
   EXTERNAL_HOSTNAME: {{ .Values.opmet.nginx.EXTERNAL_HOSTNAME | quote }}
+{{- end}}
+{{- if .Values.opmet.nginx.OAUTH2_USERINFO }}
   OAUTH2_USERINFO: {{ .Values.opmet.nginx.OAUTH2_USERINFO | quote }}
+{{- end}}
+{{- if .Values.opmet.nginx.OPMET_BACKEND_HOST }}
   OPMET_BACKEND_HOST: {{ .Values.opmet.nginx.OPMET_BACKEND_HOST | quote }}
+{{- end}}
+{{- if .Values.opmet.nginx.NGINX_PORT_HTTP }}
   NGINX_PORT_HTTP: {{ .Values.opmet.nginx.NGINX_PORT_HTTP | quote }}
+{{- end}}


### PR DESCRIPTION
Fixes issue that breaks deployments if some new values are not added in configuration. Specifially new BACKEND-, SIGMET- and AIRMET_CONFIG variables, but refactored all other config map values to be optional too to unify the implementation.