### PR TITLE
Geoweb-opmet-backend: Use variables for zalando secret names in deployment

### DIFF
--- a/charts/geoweb-opmet-backend/Chart.yaml
+++ b/charts/geoweb-opmet-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.7.0
+version: 2.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
@@ -63,12 +63,12 @@ spec:
         - name: PG_PASS
           valueFrom:
             secretKeyRef:
-              name: geoweb.opmet-db.credentials.postgresql.acid.zalan.do
+              name: {{ .Values.opmet.db.POSTGRES_USER }}.{{ .Values.opmet.db.name }}.credentials.postgresql.acid.zalan.do
               key: password
         - name: PG_USER
           valueFrom:
             secretKeyRef:
-              name: geoweb.opmet-db.credentials.postgresql.acid.zalan.do
+              name: {{ .Values.opmet.db.POSTGRES_USER }}.{{ .Values.opmet.db.name }}.credentials.postgresql.acid.zalan.do
               key: username
       {{- end }}
         - name: SQLALCHEMY_DATABASE_URL


### PR DESCRIPTION
Fixes bug: If user tries to use custom postgres user or database name, the secrets created by postgresql resource in opmet-database.yaml are created with the opmet.db.POSTGRES_USER and opmet.db.name variables, however the deployment uses secrets with hardcoded default values. In this PR the same variables are used to get the secret values in the opmet-deployment.yaml.

How to test:
* https://terraform.opengeoweb.com/opmet is now deployed with custom database name using this fix
* Code review