### PR TITLE
Geoweb-cap-backend, bump memory limit

### DIFF
--- a/charts/geoweb-cap-backend/Chart.yaml
+++ b/charts/geoweb-cap-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.3
+version: 1.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-cap-backend/values.yaml
+++ b/charts/geoweb-cap-backend/values.yaml
@@ -13,7 +13,7 @@ cap:
       memory: "250Mi"
       cpu: "50m"
     limits:
-      memory: "350Mi"
+      memory: "600Mi"
       cpu: "1"
   livenessProbe:
     httpGet:


### PR DESCRIPTION
Fixes issue where cap backend fails to start due to elevated need for memory. It is unknown why cap-backend sometimes uses almost 500Mi and sometimes 200Mi is enough. 

Current memory usage in open environments: open-acc 268Mi, open-dev 224Mi, open-prd 521Mi and new environment testing open-dev now uses 495Mi after giving higher memory memory limit with configuration to allow it to start.