### PR TITLE
New variables to geoweb-frontend & default version bump

### DIFF
--- a/charts/geoweb-frontend/Chart.yaml
+++ b/charts/geoweb-frontend/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.7
+version: 3.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v8.4.0"
+appVersion: "v9.0.0"
 
 maintainers:
   - name: Jusaa

--- a/charts/geoweb-frontend/README.md
+++ b/charts/geoweb-frontend/README.md
@@ -103,7 +103,7 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 
 | Parameter | Description | Default |
 | - | - | - |
-| `versions.frontend` | Possibility to override application version | `v8.4.0` |
+| `versions.frontend` | Possibility to override application version | `v9.0.0` |
 | `frontend.name` | Name of frontend | `geoweb` |
 | `frontend.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/opengeoweb` |
 | `frontend.commitHash` | Adds commitHash annotation to the deployment | |
@@ -155,6 +155,8 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 | `frontend.env.GW_AIRMET_BASE_URL` | Url which the application uses to connect to AIRMET backend | |
 | `frontend.env.GW_FEATURE_MODULE_SIGMET_CONFIGURATION` | Configuration used by SIGMET module | |
 | `frontend.env.GW_FEATURE_MODULE_AIRMET_CONFIGURATION` | Configuration used by AIRMET module | |
+| `frontend.env.GW_LANGUAGE` | Set language | |
+| `frontend.env.GW_FEATURE_DISPLAY_SEARCH_ON_MAP` | Enable geolocation search | |
 | `frontend.useCustomConfigurationFiles` | Use custom configurations | `false` |
 | `frontend.customConfigurationLocation` | Where custom configurations are located *(local\|s3)* | `local` |
 | `frontend.volumeAccessMode` | Permissions of the application for the custom configurations PersistentVolume used | `ReadOnlyMany` |

--- a/charts/geoweb-frontend/templates/geoweb-configmap.yaml
+++ b/charts/geoweb-frontend/templates/geoweb-configmap.yaml
@@ -85,3 +85,9 @@ data:
 {{- if .Values.frontend.env.GW_FEATURE_MODULE_AIRMET_CONFIGURATION }}
   GW_FEATURE_MODULE_AIRMET_CONFIGURATION: {{ .Values.frontend.env.GW_FEATURE_MODULE_AIRMET_CONFIGURATION | quote }}
 {{- end }}
+{{- if .Values.frontend.env.GW_LANGUAGE }}
+  GW_LANGUAGE: {{ .Values.frontend.env.GW_LANGUAGE | quote }}
+{{- end }}
+{{- if .Values.frontend.env.GW_FEATURE_DISPLAY_SEARCH_ON_MAP }}
+  GW_FEATURE_DISPLAY_SEARCH_ON_MAP: {{ .Values.frontend.env.GW_FEATURE_DISPLAY_SEARCH_ON_MAP | quote }}
+{{- end }}

--- a/charts/geoweb-frontend/values.yaml
+++ b/charts/geoweb-frontend/values.yaml
@@ -1,5 +1,5 @@
 versions:
-  frontend: "v8.4.0"
+  frontend: "v9.0.0"
 
 frontend:
   name: geoweb


### PR DESCRIPTION
* Adds support to new GW_LANGUAGE and GW_FEATURE_DISPLAY_SEARCH_ON_MAP variables to geoweb-frontend chart
* Bump default version to latest release v9.0.0 + required Chart version bump