### PR TITLE
Add SERVERS variable and support to multiple ssh keys and passphrases

### DIFF
--- a/charts/geoweb-opmet-backend/Chart.yaml
+++ b/charts/geoweb-opmet-backend/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.7.1
+version: 3.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.4.0"
+appVersion: "v2.0.0"
 
 maintainers:
   - name: Jusaa

--- a/charts/geoweb-opmet-backend/README.md
+++ b/charts/geoweb-opmet-backend/README.md
@@ -8,13 +8,19 @@ helm repo update
 # Create requried dependencies
 
 Create values.yaml file for required variables:
-* Using aws as the secret provider (use any mix of db_secret, ssh_secret and ssh_secret_passphrase)
+* Using AWS as the secret provider (use any mix of db_secret, ssh_secret and ssh_secret_passphrase)
 ```yaml
 opmet: 
   url: geoweb.example.com
   db_secret: secretName
-  ssh_secret: secretName
-  ssh_secret_passphrase: secretName
+  ssh_secrets:
+  - name: key_secret_name_in_kubernetes
+    secret: secret_name_in_AWS
+    type: secretsmanager
+  ssh_secret_passphrases:
+  - name: passphrase_secret_name_in_kubernetes
+    secret: secret_name_in_AWS
+    type: secretsmanager
   iamRoleARN: arn:aws:iam::123456789012:role/example-iam-role-with-permissions-to-secret
 
 secretProvider: aws
@@ -27,8 +33,12 @@ secretProviderParameters:
 opmet:
   url: geoweb.example.com
   db_secret: base64_encoded_postgresql_connection_string
-  ssh_secret: base64_encoded_ssh_private_key
-  ssh_secret_passphrase: base64_encoded_ssh_private_key_passphrase
+  ssh_secret:
+  - name: key_secret_name_in_kubernetes
+    secret: base64_encoded_ssh_private_key
+  ssh_secret_passphrase:
+  - name: passphrase_secret_name_in_kubernetes
+    secret: base64_encoded_ssh_private_key_passphrase
 ```
 
 * Using custom configuration files stored locally
@@ -101,7 +111,7 @@ The following table lists the configurable parameters of the Opmet backend chart
 
 | Parameter | Description | Default |
 | - | - | - |
-| `versions.opmet` | Possibility to override application version | `v1.4.0` |
+| `versions.opmet` | Possibility to override application version | `v2.0.0` |
 | `opmet.name` | Name of backend | `opmet` |
 | `opmet.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/backend-services/opmet-backend` |
 | `opmet.commitHash` | Adds commitHash annotation to the deployment | |
@@ -112,19 +122,11 @@ The following table lists the configurable parameters of the Opmet backend chart
 | `opmet.replicas` | Amount of replicas deployed | `1` |
 | `opmet.db_secret` | Secret containing base64 encoded Postgresql database connection string | |
 | `opmet.db_secretName` | Name of db secret | `opmet-db` |
-| `opmet.db_secretType` | Type to db secret | `secretsmanager` |
-| `opmet.db_secretPath` | Path to db secret | |
-| `opmet.db_secretKey` | Key of db secret | |
-| `opmet.ssh_secret` | Secret containing base64 encoded SSH private key | |
-| `opmet.ssh_secretName` | Name of ssh key secret | `opmet-publisher-ssh-key` |
-| `opmet.ssh_secretType` | Type to ssh key secret | `secretsmanager` |
-| `opmet.ssh_secretPath` | Path to ssh key secret | |
-| `opmet.ssh_secretKey` | Key of ssh key secret | |
-| `opmet.ssh_passphrase_secret` | Secret containing base64 encoded SSH private key passphrase | |
-| `opmet.ssh_passphrase_secretName` | Name of ssh passphrase secret | `opmet-publisher-ssh-passphrase` |
-| `opmet.ssh_passphrase_secretType` | Type to ssh passphrase secret | `secretsmanager` |
-| `opmet.ssh_passphrase_secretPath` | Path to ssh passphrase secret | |
-| `opmet.ssh_passphrase_secretKey` | Key of ssh passphrase secret | |
+| `opmet.db_secretType` | Type to db secret (only aws + azure) | `secretsmanager` |
+| `opmet.db_secretPath` | Path to db secret (only gcp and vault) | |
+| `opmet.db_secretKey` | Key of db secret (only vault) | |
+| `opmet.ssh_secrets` | Map to configure which ssh private key secrets you want with multiples supported, map can use values of `secret`, `name`, `type` (only aws + azure), `path` (only gcp and vault) and `key` (only vault) | |
+| `opmet.ssh_passphrase_secrets` | Map to configure which ssh private key passphrase secrets you want with multiples supported, map can use values of `secret`, `name`, `type` (only aws + azure), `path` (only gcp and vault) and `key` (only vault) | |
 | `opmet.iamRoleARN` | IAM Role with permissions to access secrets | |
 | `opmet.secretServiceAccount` | Service Account created for handling secrets | `opmet-service-account` |
 | `opmet.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
@@ -169,16 +171,7 @@ The following table lists the configurable parameters of the Opmet backend chart
 | `opmet.publisher.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/backend-services/opmet-backend/opmet-backend-publisher-local` |
 | `opmet.publisher.port` | Port used for publisher | `8090`|
 | `opmet.publisher.DESTINATION` | Folder inside publisher container where TACs are stored (used with local-publisher) | `/app/output` |
-| `opmet.publisher.USERNAME` | Username used to access SFTP server | |
-| `opmet.publisher.PASSWORD` | Password used to access SFTP server (Empty if using SSH authentication) | |
-| `opmet.publisher.PRIVATE_KEY_BASE_PATH` | Path to SSH key used to access SFTP server (Empty if using password authentication), gets combined to PRIVATE_KEY_PATH environment variable with ssh_secret added as filename | `/mnt/secrets-store/` |
-| `opmet.publisher.PRIVATE_KEY_PASSPHRASE` | SSH passphrase used for the SSH key (Empty if using password authentication)| |
-| `opmet.publisher.HOSTNAME` | Hostname of used SFTP server | |
-| `opmet.publisher.PORT` | Port used to connect to SFTP server | |
-| `opmet.publisher.REMOTE_DIR` | Folder used in the SFTP server | |
-| `opmet.publisher.TIMEOUT_SECONDS` | Timeout when trying to connect to SFTP server | |
-| `opmet.publisher.USE_TEMP_FILE` | Use temp file before publishing file to SFTP server | |
-| `opmet.publisher.TEMP_FILE_SUFFIX` | Suffix used for the temp file | |
+| `opmet.publisher.SERVERS` | List of configuration options used to access SFTP server. List of jsons. Note that ssh secrets get mounted to `/mnt/secrets-store`. Details https://gitlab.com/opengeoweb/backend-services/opmet-backend#sftp-publisher | |
 | `opmet.publisher.S3_BUCKET_NAME` | S3 Bucket used to publish files to | |
 | `opmet.publisher.volumeOptions` | yaml including the definition of the volume where TACs are published to, for example: <pre>hostPath:<br>&nbsp;&nbsp; path: /test/path</pre> or <pre>emptyDir:<br>&nbsp;&nbsp;</pre>| `emptyDir:` |
 | `opmet.publisher.resources` | Configure resource limits & requests | see defaults from `values.yaml` |

--- a/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
@@ -127,19 +127,21 @@ spec:
       {{- if .Values.opmet.publisher.readinessProbe }}
         readinessProbe: {{ toYaml .Values.opmet.publisher.readinessProbe | nindent 10 }}
       {{- end }}
+      {{- range $ssh_passphrase_secret := .Values.opmet.ssh_passphrase_secrets }}
+        env:
+        - name: {{ $ssh_passphrase_secret.name }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $ssh_passphrase_secret.name }}
+              key: SSH_KEY_PASSPHRASE
+      {{- end }}
+        - name: SERVERS
+          value: {{ .Values.opmet.publisher.SERVERS | quote }}
         envFrom:
         - configMapRef:
             name: {{ .Values.opmet.publisher.name }}
-      {{- if .Values.opmet.ssh_passphrase_secret }}
-        env:
-        - name: PRIVATE_KEY_PASSPHRASE
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.opmet.ssh_passphrase_secretName }}
-              key: SSH_KEY_PASSPHRASE
-      {{- end }}
         volumeMounts:
-      {{- if .Values.opmet.ssh_secret }}
+      {{- if and .Values.opmet.ssh_secrets .Values.opmet.ssh_passphrase_secrets }}
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
           readOnly: true
@@ -188,7 +190,7 @@ spec:
           claimName: {{ .Values.opmet.name }}-claim
       {{- end }}
     {{- end }}
-    {{- if not .Values.opmet.db.useZalandoOperatorDb }}
+    {{- if or (and .Values.opmet.db_secret (not .Values.opmet.db.useZalandoOperatorDb)) (and .Values.opmet.ssh_secrets .Values.opmet.ssh_passphrase_secrets) }}
       - name: secrets-store-inline
       {{- if .Values.secretProvider }}
         csi:
@@ -203,13 +205,13 @@ spec:
           - secret:
               name: {{ .Values.opmet.db_secretName }}
           {{- end }}
-          {{- if .Values.opmet.ssh_secret }}
+          {{- range $ssh_secret := .Values.opmet.ssh_secrets }}
           - secret:
-              name: {{ .Values.opmet.ssh_secretName }}
+              name: {{ $ssh_secret.name }}
           {{- end }}
-          {{- if .Values.opmet.ssh_passphrase_secret }}
+          {{- range $ssh_passphrase_secret := .Values.opmet.ssh_passphrase_secrets }}
           - secret:
-              name: {{ .Values.opmet.ssh_passphrase_secretName }}
+              name: {{ $ssh_passphrase_secret.name }}
           {{- end }}
       {{- end }}
     {{- end }}

--- a/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
@@ -127,16 +127,16 @@ spec:
       {{- if .Values.opmet.publisher.readinessProbe }}
         readinessProbe: {{ toYaml .Values.opmet.publisher.readinessProbe | nindent 10 }}
       {{- end }}
-      {{- range $ssh_passphrase_secret := .Values.opmet.ssh_passphrase_secrets }}
         env:
+        - name: SERVERS
+          value: {{ .Values.opmet.publisher.SERVERS | quote }}
+      {{- range $ssh_passphrase_secret := .Values.opmet.ssh_passphrase_secrets }}
         - name: {{ $ssh_passphrase_secret.name }}
           valueFrom:
             secretKeyRef:
               name: {{ $ssh_passphrase_secret.name }}
               key: SSH_KEY_PASSPHRASE
       {{- end }}
-        - name: SERVERS
-          value: {{ .Values.opmet.publisher.SERVERS | quote }}
         envFrom:
         - configMapRef:
             name: {{ .Values.opmet.publisher.name }}

--- a/charts/geoweb-opmet-backend/templates/opmet-publisher-configmap.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-publisher-configmap.yaml
@@ -10,36 +10,9 @@ data:
 {{- if .Values.opmet.publisher.DESTINATION }}
   DESTINATION: {{ .Values.opmet.publisher.DESTINATION | quote }}
 {{- end }}
-{{- if .Values.opmet.publisher.USERNAME }}
-  USERNAME: {{ .Values.opmet.publisher.USERNAME | quote }}
-{{- end }}
-{{- if .Values.opmet.publisher.PASSWORD }}
-  PASSWORD: {{ .Values.opmet.publisher.PASSWORD | quote }}
-{{- end }}
-{{- if and .Values.opmet.publisher.PRIVATE_KEY_BASE_PATH .Values.opmet.ssh_secret }}
-  PRIVATE_KEY_PATH: "{{ .Values.opmet.publisher.PRIVATE_KEY_BASE_PATH }}{{ .Values.opmet.ssh_secret }}"
-{{- end }}
-{{- if .Values.opmet.publisher.PRIVATE_KEY_PASSPHRASE }}
-  PRIVATE_KEY_PASSPHRASE: {{ .Values.opmet.publisher.PRIVATE_KEY_PASSPHRASE | quote }}
-{{- end }}
-{{- if .Values.opmet.publisher.HOSTNAME }}
-  HOSTNAME: {{ .Values.opmet.publisher.HOSTNAME | quote }}
-{{- end }}
-{{- if .Values.opmet.publisher.PORT }}
-  PORT: {{ .Values.opmet.publisher.PORT | quote }}
-{{- end }}
-{{- if .Values.opmet.publisher.REMOTE_DIR }}
-  REMOTE_DIR: {{ .Values.opmet.publisher.REMOTE_DIR | quote }}
-{{- end }}
-{{- if .Values.opmet.publisher.TIMEOUT_SECONDS }}
-  TIMEOUT_SECONDS: {{ .Values.opmet.publisher.TIMEOUT_SECONDS | quote }}
-{{- end }}
-{{- if .Values.opmet.publisher.USE_TEMP_FILE }}
-  USE_TEMP_FILE: {{ .Values.opmet.publisher.USE_TEMP_FILE | quote }}
-{{- end }}
-{{- if .Values.opmet.publisher.TEMP_FILE_SUFFIX }}
-  TEMP_FILE_SUFFIX: {{ .Values.opmet.publisher.TEMP_FILE_SUFFIX | quote }}
-{{- end }}
+#{{- if .Values.opmet.publisher.SERVERS }}
+#  SERVERS: {{ .Values.opmet.publisher.SERVERS | quote }}
+#{{- end }}
 {{- if .Values.opmet.publisher.S3_BUCKET_NAME }}
   S3_BUCKET_NAME: {{ .Values.opmet.publisher.S3_BUCKET_NAME | quote }}
 {{- end }}

--- a/charts/geoweb-opmet-backend/templates/opmet-publisher-configmap.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-publisher-configmap.yaml
@@ -10,9 +10,9 @@ data:
 {{- if .Values.opmet.publisher.DESTINATION }}
   DESTINATION: {{ .Values.opmet.publisher.DESTINATION | quote }}
 {{- end }}
-#{{- if .Values.opmet.publisher.SERVERS }}
-#  SERVERS: {{ .Values.opmet.publisher.SERVERS | quote }}
-#{{- end }}
+{{- if .Values.opmet.publisher.SERVERS }}
+  SERVERS: {{ .Values.opmet.publisher.SERVERS | quote }}
+{{- end }}
 {{- if .Values.opmet.publisher.S3_BUCKET_NAME }}
   S3_BUCKET_NAME: {{ .Values.opmet.publisher.S3_BUCKET_NAME | quote }}
 {{- end }}

--- a/charts/geoweb-opmet-backend/templates/opmet-secrets.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-secrets.yaml
@@ -5,53 +5,51 @@ metadata:
   name: {{ .Values.opmet.spcName }}
 spec:
   provider: {{ .Values.secretProvider }}
-  parameters:
-  {{- if or (eq .Values.secretProvider "aws") (eq .Values.secretProvider "azure") }}
+  parameters: # Fetches secrets from configured secretProvider
+{{- if or (eq .Values.secretProvider "aws") (eq .Values.secretProvider "azure") (eq .Values.secretProvider "vault") }}
     objects: |
-    {{- if and .Values.opmet.db_secret (not .Values.opmet.db.useZalandoOperatorDb) }}
+{{- else if eq .Values.secretProvider "gcp" }}
+    secrets: |
+{{- end }}
+  {{- if and .Values.opmet.db_secret (not .Values.opmet.db.useZalandoOperatorDb) }}
+    {{- if or (eq .Values.secretProvider "aws") (eq .Values.secretProvider "azure") }}
       - objectName: {{ .Values.opmet.db_secret | quote }}
         objectType: {{ .Values.opmet.db_secretType | quote }}
-    {{- end }}
-    {{- if .Values.opmet.ssh_secret }}
-      - objectName: {{ .Values.opmet.ssh_secret | quote }}
-        objectType: {{ .Values.opmet.ssh_secretType | quote }}
-    {{- end }}
-    {{- if .Values.opmet.ssh_passphrase_secret }}
-      - objectName: {{ .Values.opmet.ssh_passphrase_secret | quote }}
-        objectType: {{ .Values.opmet.ssh_passphrase_secretType | quote }}
-    {{- end }}
-  {{- else if eq .Values.secretProvider "gcp" }}
-    secrets: |
-    {{- if and .Values.opmet.db_secret (not .Values.opmet.db.useZalandoOperatorDb) }}
+    {{- else if eq .Values.secretProvider "gcp" }}
       - resourceName: {{ .Values.opmet.db_secret | quote }}
         path: {{ .Values.opmet.db_secretPath | quote }}
-    {{- end }}
-    {{- if .Values.opmet.ssh_secret }}
-      - resourceName: {{ .Values.opmet.ssh_secret | quote }}
-        path: {{ .Values.opmet.ssh_secretPath | quote }}
-    {{- end }}
-    {{- if .Values.opmet.ssh_passphrase_secret }}
-      - resourceName: {{ .Values.opmet.ssh_passphrase_secret | quote }}
-        path: {{ .Values.opmet.ssh_passphrase_secretPath | quote }}
-    {{- end }}
-  {{- else if eq .Values.secretProvider "vault" }}
-    objects: |
-    {{- if and .Values.opmet.db_secret (not .Values.opmet.db.useZalandoOperatorDb) }}
+    {{- else if eq .Values.secretProvider "vault" }}
       - objectName: {{ .Values.opmet.db_secret | quote }}
         secretPath: {{ .Values.opmet.db_secretPath | quote }}
         secretKey: {{ .Values.opmet.db_secretKey | quote }}
     {{- end }}
-    {{- if .Values.opmet.ssh_secret }}
-      - objectName: {{ .Values.opmet.ssh_secret | quote }}
-        secretPath: {{ .Values.opmet.ssh_secretPath | quote }}
-        secretKey: {{ .Values.opmet.ssh_secretKey | quote }}
-    {{- end }}
-    {{- if .Values.opmet.ssh_passphrase_secret }}
-      - objectName: {{ .Values.opmet.ssh_passphrase_secret | quote }}
-        secretPath: {{ .Values.opmet.ssh_passphrase_secretPath | quote }}
-        secretKey: {{ .Values.opmet.ssh_passphrase_secretKey | quote }}
-    {{- end }}
   {{- end }}
+  {{- range $ssh_passphrase_secret := .Values.opmet.ssh_passphrase_secrets }}
+    {{- if or (eq $.Values.secretProvider "aws") (eq $.Values.secretProvider "azure") }}
+      - objectName: {{ $ssh_passphrase_secret.secret | quote }}
+        objectType: {{ $ssh_passphrase_secret.type | quote }}
+    {{- else if eq $.Values.secretProvider "gcp" }}
+      - resourceName: {{ $ssh_passphrase_secret.secret | quote }}
+        path: {{ $ssh_passphrase_secret.path | quote }}
+    {{- else if eq $.Values.secretProvider "vault" }}
+      - objectName: {{ $ssh_passphrase_secret.secret | quote }}
+        secretPath: {{ $ssh_passphrase_secret.path | quote }}
+        secretKey: {{ $ssh_passphrase_secret.key | quote }}
+    {{- end }}
+  {{- end}}
+  {{- range $ssh_secret := .Values.opmet.ssh_secrets }}
+    {{- if or (eq $.Values.secretProvider "aws") (eq $.Values.secretProvider "azure") }}
+      - objectName: {{ $ssh_secret.secret | quote }}
+        objectType: {{ $ssh_secret.type | quote }}
+    {{- else if eq $.Values.secretProvider "gcp" }}
+      - resourceName: {{ $ssh_secret.secret | quote }}
+        path: {{ $ssh_secret.path | quote }}
+    {{- else if eq $.Values.secretProvider "vault" }}
+      - objectName: {{ $ssh_secret.secret | quote }}
+        secretPath: {{ $ssh_secret.path | quote }}
+        secretKey: {{ $ssh_secret.key | quote }}
+    {{- end }}
+  {{- end}}
   {{- range $key, $value := .Values.secretProviderParameters }}
     {{ $key }}: {{ $value }}
   {{- end }}
@@ -63,18 +61,18 @@ spec:
     secretName: {{ .Values.opmet.db_secretName }}
     type: Opaque
   {{- end }}
-  {{- if .Values.opmet.ssh_secret }}
+  {{- range $ssh_secret := .Values.opmet.ssh_secrets }}
   - data:
     - key: ssh-privatekey
-      objectName: {{ .Values.opmet.ssh_secret }}
-    secretName: {{ .Values.opmet.ssh_secretName }}
+      objectName: {{ $ssh_secret.secret }}
+    secretName: {{ $ssh_secret.name }}
     type: kubernetes.io/ssh-auth
   {{- end }}
-  {{- if .Values.opmet.ssh_passphrase_secret }}
+  {{- range $ssh_passphrase_secret := .Values.opmet.ssh_passphrase_secrets }}
   - data:
     - key: SSH_KEY_PASSPHRASE
-      objectName: {{ .Values.opmet.ssh_passphrase_secret }}
-    secretName: {{ .Values.opmet.ssh_passphrase_secretName }}
+      objectName: {{ $ssh_passphrase_secret.secret }}
+    secretName: {{ $ssh_passphrase_secret.name }}
     type: Opaque
   {{- end }}
 {{- else }}
@@ -86,23 +84,23 @@ metadata:
 data:
   OPMET_BACKEND_DB: {{ .Values.opmet.db_secret }}
 {{- end }}
-{{- if .Values.opmet.ssh_secret }}
+{{- range $ssh_passphrase_secret := .Values.opmet.ssh_passphrase_secrets }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.opmet.ssh_passphrase_secretName }}
+  name: {{ $ssh_passphrase_secret.name }}
 data:
-  SSH_KEY_PASSPHRASE: {{ .Values.opmet.ssh_passphrase_secret }}
+  SSH_KEY_PASSPHRASE: {{ $ssh_passphrase_secret.secret }}
 {{- end }}
-{{- if .Values.opmet.ssh_passphrase_secret }}
+{{- range $ssh_secret := .Values.opmet.ssh_secrets }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.opmet.ssh_secretName }}
+  name: {{ $ssh_secret.name }}
 type: kubernetes.io/ssh-auth
 data:
-  ssh-privatekey: {{ .Values.opmet.ssh_secret }}
+  ssh-privatekey: {{ $ssh_secret.secret }}
 {{- end }}
 {{- end }}

--- a/charts/geoweb-opmet-backend/values.yaml
+++ b/charts/geoweb-opmet-backend/values.yaml
@@ -1,5 +1,5 @@
 versions:
-  opmet: "v1.4.0"
+  opmet: "v2.0.0"
 
 opmet:
   name: opmet
@@ -10,10 +10,6 @@ opmet:
   db_secret: cG9zdGdyZXNxbDovL2dlb3dlYjpwb3N0Z3Jlc0Bsb2NhbGhvc3Q6NTQzMi9vcG1ldA==
   db_secretName: opmet-db
   db_secretType: secretsmanager
-  ssh_secretName: opmet-publisher-ssh-key
-  ssh_secretType: secretsmanager
-  ssh_passphrase_secretName: opmet-publisher-ssh-passphrase
-  ssh_passphrase_secretType: secretsmanager
   spcName: opmet-spc
   secretServiceAccount: opmet-service-account
   resources:
@@ -72,7 +68,6 @@ opmet:
     registry: registry.gitlab.com/opengeoweb/backend-services/opmet-backend/opmet-backend-publisher-local
     port: 8090
     DESTINATION: /app/output
-    PRIVATE_KEY_BASE_PATH: /mnt/secrets-store/
     resources:
       requests:
         memory: "50Mi"


### PR DESCRIPTION
* Adds SERVERS env variable for configuring SFTP publisher
  * Removed the values that SERVERS replaced
* Adds functionality to use multiple ssh keys and passphrases
  * Lots of refactoring due to this
* Version update to v2.0.0 which uses SERVERS env variable

Closes https://gitlab.com/opengeoweb/backend-services/opmet-backend/-/issues/119