### PR TITLE
Fix SERVERS env working with passphrase secret

### DIFF
--- a/charts/geoweb-opmet-backend/Chart.yaml
+++ b/charts/geoweb-opmet-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.0
+version: 3.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
@@ -128,8 +128,6 @@ spec:
         readinessProbe: {{ toYaml .Values.opmet.publisher.readinessProbe | nindent 10 }}
       {{- end }}
         env:
-        - name: SERVERS
-          value: {{ .Values.opmet.publisher.SERVERS | quote }}
       {{- range $ssh_passphrase_secret := .Values.opmet.ssh_passphrase_secrets }}
         - name: {{ $ssh_passphrase_secret.name }}
           valueFrom:
@@ -137,6 +135,8 @@ spec:
               name: {{ $ssh_passphrase_secret.name }}
               key: SSH_KEY_PASSPHRASE
       {{- end }}
+        - name: SERVERS
+          value: {{ .Values.opmet.publisher.SERVERS | quote }}
         envFrom:
         - configMapRef:
             name: {{ .Values.opmet.publisher.name }}


### PR DESCRIPTION
* Move SERVERS env after setting passphrase env, so user can propagate the value properly
  * Including $(passphrase-secret-name) in the SERVERS env variable now correctly propagates to passphrase-secret-name secret value, tested with test deployment