### PR TITLE
Use appVersion as default instead of always relying on versions.application

### DIFF
--- a/charts/geoweb-cap-backend/Chart.yaml
+++ b/charts/geoweb-cap-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.5
+version: 1.3.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-cap-backend/README.md
+++ b/charts/geoweb-cap-backend/README.md
@@ -43,7 +43,7 @@ The following table lists the configurable parameters of the CAP backend chart a
 
 | Parameter | Description | Default |
 | - | - | - |
-| `versions.cap` | Possibility to override application version | `v0.6.0` |
+| `versions.cap` | Possibility to override application version | |
 | `cap.name` | Name of backend | `cap` |
 | `cap.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/backend-services/cap-backend` |
 | `cap.commitHash` | Adds commitHash annotation to the deployment | |

--- a/charts/geoweb-cap-backend/templates/cap-deployment.yaml
+++ b/charts/geoweb-cap-backend/templates/cap-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: {{ .Values.cap.name }}
-        image: {{ .Values.cap.registry }}:{{ .Values.versions.cap }}
+        image: {{ .Values.cap.registry }}:{{ default .Chart.AppVersion .Values.versions.cap }}
       {{- if .Values.cap.imagePullPolicy }}
         imagePullPolicy: {{ .Values.cap.imagePullPolicy }}
       {{- end }}

--- a/charts/geoweb-cap-backend/values.yaml
+++ b/charts/geoweb-cap-backend/values.yaml
@@ -1,5 +1,5 @@
 versions:
-  cap: "v0.6.0"
+  cap:
 
 cap:
   name: cap

--- a/charts/geoweb-frontend/Chart.yaml
+++ b/charts/geoweb-frontend/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.1
+version: 3.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v9.1.0"
+appVersion: "v9.3.0"
 
 maintainers:
   - name: Jusaa

--- a/charts/geoweb-frontend/README.md
+++ b/charts/geoweb-frontend/README.md
@@ -103,7 +103,7 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 
 | Parameter | Description | Default |
 | - | - | - |
-| `versions.frontend` | Possibility to override application version | `v9.1.0` |
+| `versions.frontend` | Possibility to override application version | |
 | `frontend.name` | Name of frontend | `geoweb` |
 | `frontend.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/opengeoweb` |
 | `frontend.commitHash` | Adds commitHash annotation to the deployment | |

--- a/charts/geoweb-frontend/templates/geoweb-deployment.yaml
+++ b/charts/geoweb-frontend/templates/geoweb-deployment.yaml
@@ -40,7 +40,7 @@ spec:
     {{- end }}
       containers:
       - name: {{ .Values.frontend.name }}
-        image: {{ .Values.frontend.registry }}:{{ .Values.versions.frontend }}
+        image: {{ .Values.frontend.registry }}:{{ default .Chart.AppVersion .Values.versions.frontend }}
       {{- if .Values.frontend.imagePullPolicy }}
         imagePullPolicy: {{ .Values.frontend.imagePullPolicy }}
       {{- end }}

--- a/charts/geoweb-frontend/values.yaml
+++ b/charts/geoweb-frontend/values.yaml
@@ -1,5 +1,5 @@
 versions:
-  frontend: "v9.1.0"
+  frontend:
 
 frontend:
   name: geoweb

--- a/charts/geoweb-opmet-backend/Chart.yaml
+++ b/charts/geoweb-opmet-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.3
+version: 3.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-opmet-backend/README.md
+++ b/charts/geoweb-opmet-backend/README.md
@@ -111,7 +111,7 @@ The following table lists the configurable parameters of the Opmet backend chart
 
 | Parameter | Description | Default |
 | - | - | - |
-| `versions.opmet` | Possibility to override application version | `v2.2.0` |
+| `versions.opmet` | Possibility to override application version | |
 | `opmet.name` | Name of backend | `opmet` |
 | `opmet.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/backend-services/opmet-backend` |
 | `opmet.commitHash` | Adds commitHash annotation to the deployment | |
@@ -152,7 +152,7 @@ The following table lists the configurable parameters of the Opmet backend chart
 | `opmet.awsDefaultRegion` | Region where your S3 bucket is located | |
 | `opmet.messageconverter.name` | Name of messageconverter container | `opmet-messageconverter` |
 | `opmet.messageconverter.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/avi-msgconverter/geoweb-knmi-avi-messageservices` |
-| `opmet.messageconverter.version` | Possibility to override application version | `"0.1.1"` |
+| `opmet.messageconverter.version` | Possibility to override application version | see default from `values.yaml` |
 | `opmet.messageconverter.port` | Port used for messageconverter | `8080` |
 | `opmet.messageconverter.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `opmet.messageconverter.livenessProbe` | Configure libenessProbe | see defaults from `values.yaml` |

--- a/charts/geoweb-opmet-backend/templates/opmet-configmap.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-configmap.yaml
@@ -7,9 +7,7 @@ metadata:
     commitHash: {{ .Values.opmet.commitHash }}
   {{- end }}
 data:
-{{- if .Values.versions.opmet }}
-  VERSION: {{ .Values.versions.opmet | quote }}
-{{- end }}
+  VERSION: {{ default .Chart.AppVersion .Values.versions.opmet | quote }}
 {{- if .Values.opmet.env.MESSAGECONVERTER_URL }}
   MESSAGECONVERTER_URL: {{ .Values.opmet.env.MESSAGECONVERTER_URL | quote }}
 {{- end }}

--- a/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-deployment.yaml
@@ -40,7 +40,7 @@ spec:
     {{- end }}
       containers:
       - name: {{ .Values.opmet.name }}
-        image: {{ .Values.opmet.registry }}:{{ .Values.versions.opmet }}
+        image: {{ .Values.opmet.registry }}:{{ default .Chart.AppVersion .Values.versions.opmet }}
       {{- if .Values.opmet.imagePullPolicy }}
         imagePullPolicy: {{ .Values.opmet.imagePullPolicy }}
       {{- end }}
@@ -112,7 +112,7 @@ spec:
         - configMapRef:
             name: {{ .Values.opmet.name }}
       - name: {{ .Values.opmet.publisher.name }}
-        image: {{ .Values.opmet.publisher.registry }}:{{ .Values.versions.opmet }}
+        image: {{ .Values.opmet.publisher.registry }}:{{ default .Chart.AppVersion .Values.versions.opmet }}
       {{- if .Values.opmet.imagePullPolicy }}
         imagePullPolicy: {{ .Values.opmet.imagePullPolicy }}
       {{- end }}
@@ -149,7 +149,7 @@ spec:
         - name: publisher-volume
           mountPath: {{ .Values.opmet.publisher.DESTINATION | quote }}
       - name: {{ .Values.opmet.nginx.name }}
-        image: {{ .Values.opmet.nginx.registry }}:{{ .Values.versions.opmet }}
+        image: {{ .Values.opmet.nginx.registry }}:{{ default .Chart.AppVersion .Values.versions.opmet }}
       {{- if .Values.opmet.imagePullPolicy }}
         imagePullPolicy: {{ .Values.opmet.imagePullPolicy }}
       {{- end }}

--- a/charts/geoweb-opmet-backend/values.yaml
+++ b/charts/geoweb-opmet-backend/values.yaml
@@ -1,5 +1,5 @@
 versions:
-  opmet: "v2.2.0"
+  opmet:
 
 opmet:
   name: opmet

--- a/charts/geoweb-presets-backend/Chart.yaml
+++ b/charts/geoweb-presets-backend/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.2
+version: 2.6.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.6.2"
+appVersion: "3.6.3"
 
 maintainers:
   - name: Jusaa

--- a/charts/geoweb-presets-backend/README.md
+++ b/charts/geoweb-presets-backend/README.md
@@ -78,7 +78,7 @@ The following table lists the configurable parameters of the Presets backend cha
 
 | Parameter | Description | Default |
 | - | - | - |
-| `versions.presets` | Possibility to override application version | `3.6.2` |
+| `versions.presets` | Possibility to override application version | |
 | `presets.name` | Name of backend | `presets` |
 | `presets.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/backend-services/presets-backend` |
 | `presets.commitHash` | Adds commitHash annotation to the deployment | |

--- a/charts/geoweb-presets-backend/templates/presets-configmap.yaml
+++ b/charts/geoweb-presets-backend/templates/presets-configmap.yaml
@@ -7,9 +7,7 @@ metadata:
     commitHash: {{ .Values.presets.commitHash }}
   {{- end }}
 data:
-{{- if .Values.versions.presets }}
-  VERSION: {{ .Values.versions.presets | quote }}
-{{- end }}
+  VERSION: {{ default .Chart.AppVersion .Values.versions.presets | quote }}
 {{- if .Values.presets.PRESETS_PORT_HTTP }}
   PRESETS_PORT_HTTP: {{ .Values.presets.PRESETS_PORT_HTTP | quote }}
 {{- end }}

--- a/charts/geoweb-presets-backend/templates/presets-deployment.yaml
+++ b/charts/geoweb-presets-backend/templates/presets-deployment.yaml
@@ -40,7 +40,7 @@ spec:
     {{- end }}
       containers:
       - name: {{ .Values.presets.name }}
-        image: {{ .Values.presets.registry }}:{{ .Values.versions.presets }}
+        image: {{ .Values.presets.registry }}:{{ default .Chart.AppVersion .Values.versions.presets }}
       {{- if .Values.presets.imagePullPolicy }}
         imagePullPolicy: {{ .Values.presets.imagePullPolicy }}
       {{- end }}
@@ -79,7 +79,7 @@ spec:
           name: {{ .Values.presets.name }}-volume
       {{- end }}
       - name: {{ .Values.presets.nginx.name }}
-        image: {{ .Values.presets.nginx.registry }}:{{ .Values.versions.presets }}
+        image: {{ .Values.presets.nginx.registry }}:{{ default .Chart.AppVersion .Values.versions.presets }}
       {{- if .Values.presets.imagePullPolicy }}
         imagePullPolicy: {{ .Values.presets.imagePullPolicy }}
       {{- end }}

--- a/charts/geoweb-presets-backend/values.yaml
+++ b/charts/geoweb-presets-backend/values.yaml
@@ -1,5 +1,5 @@
 versions:
-  presets: "3.6.2"
+  presets:
 
 presets:
   name: presets

--- a/charts/geoweb-taf-backend/Chart.yaml
+++ b/charts/geoweb-taf-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-taf-backend/README.md
+++ b/charts/geoweb-taf-backend/README.md
@@ -82,7 +82,7 @@ The following table lists the configurable parameters of the Taf backend chart a
 
 | Parameter | Description | Default |
 | - | - | - |
-| `versions.taf` | Possibility to override application version | `v0.0.5` |
+| `versions.taf` | Possibility to override application version | |
 | `taf.name` | Name of backend | `taf` |
 | `taf.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/backend-services/aviation-taf-backend/aviation-taf-backend` |
 | `taf.commitHash` | Adds commitHash annotation to the deployment | |
@@ -119,7 +119,7 @@ The following table lists the configurable parameters of the Taf backend chart a
 | `taf.awsDefaultRegion` | Region where your S3 bucket is located | |
 | `taf.messageconverter.name` | Name of messageconverter container | `taf-messageconverter` |
 | `taf.messageconverter.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/avi-msgconverter/geoweb-knmi-avi-messageservices` |
-| `taf.messageconverter.version` | Possibility to override application version | `"0.1.1"` |
+| `taf.messageconverter.version` | Possibility to override application version | see default from `values.yaml` |
 | `taf.messageconverter.port` | Port used for messageconverter | `8080` |
 | `taf.messageconverter.resources` | Configure resource limits & requests | see defaults from `values.yaml` |
 | `taf.messageconverter.livenessProbe` | Configure libenessProbe | see defaults from `values.yaml` |

--- a/charts/geoweb-taf-backend/templates/taf-configmap.yaml
+++ b/charts/geoweb-taf-backend/templates/taf-configmap.yaml
@@ -7,6 +7,7 @@ metadata:
     commitHash: {{ .Values.taf.commitHash }}
   {{- end }}
 data:
+  VERSION: {{ default .Chart.AppVersion .Values.versions.taf | quote }}
 {{- if .Values.taf.env.GEOWEB_KNMI_AVI_MESSAGESERVICES_HOST }}
   GEOWEB_KNMI_AVI_MESSAGESERVICES_HOST: {{ .Values.taf.env.GEOWEB_KNMI_AVI_MESSAGESERVICES_HOST | quote }}
 {{- end }}
@@ -18,9 +19,6 @@ data:
 {{- end }}
 {{- if .Values.taf.env.TAF_CONFIG }}
   TAF_CONFIG: {{ .Values.taf.env.TAF_CONFIG | quote }}
-{{- end }}
-{{- if .Values.versions.taf }}
-  VERSION: {{ .Values.versions.taf | quote }}
 {{- end }}
 {{- if .Values.taf.messageconverter.version }}
   AVI_VERSION: {{ .Values.taf.messageconverter.version | quote }}

--- a/charts/geoweb-taf-backend/templates/taf-deployment.yaml
+++ b/charts/geoweb-taf-backend/templates/taf-deployment.yaml
@@ -40,7 +40,7 @@ spec:
     {{- end }}
       containers:
       - name: {{ .Values.taf.name }}
-        image: {{ .Values.taf.registry }}:{{ .Values.versions.taf }}
+        image: {{ .Values.taf.registry }}:{{ default .Chart.AppVersion .Values.versions.taf }}
       {{- if .Values.taf.imagePullPolicy }}
         imagePullPolicy: {{ .Values.taf.imagePullPolicy }}
       {{- end }}
@@ -79,7 +79,7 @@ spec:
           name: {{ .Values.taf.name }}-volume
       {{- end }}
       - name: {{ .Values.taf.placeholder.name }}
-        image: {{ .Values.taf.placeholder.registry }}:{{ .Values.versions.taf }}
+        image: {{ .Values.taf.placeholder.registry }}:{{ default .Chart.AppVersion .Values.versions.taf }}
       {{- if .Values.taf.imagePullPolicy }}
         imagePullPolicy: {{ .Values.taf.imagePullPolicy }}
       {{- end }}
@@ -129,7 +129,7 @@ spec:
         - configMapRef:
             name: {{ .Values.taf.name }}
       - name: {{ .Values.taf.publisher.name }}
-        image: {{ .Values.taf.publisher.registry }}:{{ .Values.versions.taf }}
+        image: {{ .Values.taf.publisher.registry }}:{{ default .Chart.AppVersion .Values.versions.taf }}
       {{- if .Values.taf.imagePullPolicy }}
         imagePullPolicy: {{ .Values.taf.imagePullPolicy }}
       {{- end }}
@@ -151,7 +151,7 @@ spec:
         - name: publisher-volume
           mountPath: {{ .Values.taf.publisher.PUBLISH_DIR | quote }}
       - name: {{ .Values.taf.nginx.name }}
-        image: {{ .Values.taf.nginx.registry }}:{{ .Values.versions.taf }}
+        image: {{ .Values.taf.nginx.registry }}:{{ default .Chart.AppVersion .Values.versions.taf }}
       {{- if .Values.taf.imagePullPolicy }}
         imagePullPolicy: {{ .Values.taf.imagePullPolicy }}
       {{- end }}

--- a/charts/geoweb-taf-backend/values.yaml
+++ b/charts/geoweb-taf-backend/values.yaml
@@ -1,5 +1,5 @@
 versions:
-  taf: "v0.0.5"
+  taf:
 
 taf:
   name: taf

--- a/charts/geoweb-warnings-backend/Chart.yaml
+++ b/charts/geoweb-warnings-backend/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.0"
+appVersion: "0.5.0"
 
 maintainers:
   - name: Jusaa

--- a/charts/geoweb-warnings-backend/README.md
+++ b/charts/geoweb-warnings-backend/README.md
@@ -57,7 +57,7 @@ The following table lists the configurable parameters of the Warnings backend ch
 
 | Parameter | Description | Default |
 | - | - | - |
-| `versions.warnings` | Possibility to override application version | `0.4.0` |
+| `versions.warnings` | Possibility to override application version | |
 | `warnings.name` | Name of backend | `warnings` |
 | `warnings.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/backend-services/warnings-backend` |
 | `warnings.commitHash` | Adds commitHash annotation to the deployment | |

--- a/charts/geoweb-warnings-backend/templates/warnings-configmap.yaml
+++ b/charts/geoweb-warnings-backend/templates/warnings-configmap.yaml
@@ -7,9 +7,7 @@ metadata:
     commitHash: {{ .Values.warnings.commitHash }}
   {{- end }}
 data:
-{{- if .Values.versions.warnings }}
-  VERSION: {{ .Values.versions.warnings | quote }}
-{{- end }}
+  VERSION: {{ default .Chart.AppVersion .Values.versions.warnings | quote }}
 {{- if .Values.warnings.WARNINGS_PORT_HTTP }}
   WARNINGS_PORT_HTTP: {{ .Values.warnings.WARNINGS_PORT_HTTP | quote }}
 {{- end }}

--- a/charts/geoweb-warnings-backend/templates/warnings-deployment.yaml
+++ b/charts/geoweb-warnings-backend/templates/warnings-deployment.yaml
@@ -24,7 +24,7 @@ spec:
     {{- end }}
       containers:
       - name: {{ .Values.warnings.name }}
-        image: {{ .Values.warnings.registry }}:{{ .Values.versions.warnings }}
+        image: {{ .Values.warnings.registry }}:{{ default .Chart.AppVersion .Values.versions.warnings }}
       {{- if .Values.warnings.imagePullPolicy }}
         imagePullPolicy: {{ .Values.warnings.imagePullPolicy }}
       {{- end }}
@@ -59,7 +59,7 @@ spec:
           mountPath: "/mnt/secrets-store"
           readOnly: true
       - name: {{ .Values.warnings.nginx.name }}
-        image: {{ .Values.warnings.nginx.registry }}:{{ .Values.versions.warnings }}
+        image: {{ .Values.warnings.nginx.registry }}:{{ default .Chart.AppVersion .Values.versions.warnings }}
       {{- if .Values.warnings.imagePullPolicy }}
         imagePullPolicy: {{ .Values.warnings.imagePullPolicy }}
       {{- end }}

--- a/charts/geoweb-warnings-backend/values.yaml
+++ b/charts/geoweb-warnings-backend/values.yaml
@@ -1,5 +1,5 @@
 versions:
-  warnings: "0.4.0"
+  warnings:
 
 warnings:
   name: warnings


### PR DESCRIPTION
Fixes an Chart update problem as developer needed to update 3 different values when bumping the version, now only 1 value needs to be updated for simplicity.
* Removed default value from versions.application from values.yaml and README
  * values.yaml needs to have the empty versions.appplication defined, otherwise null pointer error will occur
  * Also removed messageconverter default values from README so it also needs 1 value to be updated
* Added default .Chart.appVersion to all the places where versions.application is used
* Removed VERSION config map variable condition as default appVersion is always set
* Some version bumps to latest releases

How to test:
* Code review & You can apply charts locally with --dry-run option to see that the version is correctly applied

Closes https://gitlab.com/opengeoweb/fmi/fmi-aws-config/-/issues/219