### PR TITLE
Added zalando database support for rest of the geoweb backends

### DIFF
--- a/charts/geoweb-presets-backend/Chart.yaml
+++ b/charts/geoweb-presets-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.3
+version: 2.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-presets-backend/README.md
+++ b/charts/geoweb-presets-backend/README.md
@@ -48,6 +48,17 @@ presets:
   awsDefaultRegion: <AWS_DEFAULT_REGION>
 ```
 
+* Using Zalando Operator Database
+```yaml
+presets:
+  url: geoweb.example.com
+  db:
+    enableDefaultDb: false
+    useZalandoOperatorDb: true
+    cleanInstall: false # Add this line only after first install
+    backupBucket: s3://<S3-bucket-name>/
+```
+
 # Testing the Chart
 Execute the following for testing the chart:
 

--- a/charts/geoweb-presets-backend/templates/presets-database.yaml
+++ b/charts/geoweb-presets-backend/templates/presets-database.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.presets.db.useZalandoOperatorDb }}
+apiVersion: "acid.zalan.do/v1"
+kind: postgresql
+metadata:
+  name: {{ .Values.presets.db.name }}
+spec:
+  teamId: {{ .Values.presets.db.zalandoTeamId }}
+  volume:
+    size: {{ .Values.presets.db.instanceSize }}
+  numberOfInstances: {{ .Values.presets.db.numberOfInstances }}
+  users:
+    {{ .Values.presets.db.POSTGRES_USER }}:
+    - superuser
+    - createdb
+  databases:
+    {{ .Values.presets.db.POSTGRES_DB }}: {{ .Values.presets.db.POSTGRES_USER }}
+  postgresql:
+    version: {{ .Values.presets.db.POSTGRES_VERSION | quote }}
+  enableLogicalBackup: {{ .Values.presets.db.enableLogicalBackup }}
+  {{- if not .Values.presets.db.cleanInstall }}
+  clone:
+    cluster: {{ .Values.presets.db.name | quote }}
+    timestamp: {{ .Values.presets.db.backupTimestamp | quote }}
+    s3_wal_path: {{ .Values.presets.db.backupBucket | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/geoweb-presets-backend/templates/presets-deployment.yaml
+++ b/charts/geoweb-presets-backend/templates/presets-deployment.yaml
@@ -138,7 +138,7 @@ spec:
           claimName: {{ .Values.presets.name }}-claim
       {{- end }}
     {{- end }}
-    {{- if not .Values.taf.db.useZalandoOperatorDb }}
+    {{- if not .Values.presets.db.useZalandoOperatorDb }}
       - name: secrets-store-inline
       {{- if .Values.secretProvider }}
         csi:

--- a/charts/geoweb-presets-backend/templates/presets-deployment.yaml
+++ b/charts/geoweb-presets-backend/templates/presets-deployment.yaml
@@ -65,15 +65,33 @@ spec:
         - configMapRef:
             name: {{ .Values.presets.name }}
         env:
+      {{- if .Values.presets.db.useZalandoOperatorDb }}
+        - name: PG_PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.presets.db.POSTGRES_USER }}.{{ .Values.presets.db.name }}.credentials.postgresql.acid.zalan.do
+              key: password
+        - name: PG_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.presets.db.POSTGRES_USER }}.{{ .Values.presets.db.name }}.credentials.postgresql.acid.zalan.do
+              key: username
+      {{- end }}
         - name: PRESETS_BACKEND_DB
+        {{- if .Values.presets.db.useZalandoOperatorDb }}
+          value: "postgresql://$(PG_USER):$(PG_PASS)@{{ .Values.presets.db.name }}:5432/{{ .Values.presets.db.POSTGRES_DB }}"
+        {{- else }}
           valueFrom:
             secretKeyRef:
               name: {{ .Values.presets.db_secretName }}
               key: PRESETS_BACKEND_DB
+        {{- end }}
+      {{- if not .Values.presets.db.useZalandoOperatorDb }}
         volumeMounts:
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
           readOnly: true
+      {{- end }}
       {{- if and .Values.presets.useCustomWorkspacePresets }}
         - mountPath: "/app/staticpresets"
           name: {{ .Values.presets.name }}-volume
@@ -120,6 +138,7 @@ spec:
           claimName: {{ .Values.presets.name }}-claim
       {{- end }}
     {{- end }}
+    {{- if not .Values.taf.db.useZalandoOperatorDb }}
       - name: secrets-store-inline
       {{- if .Values.secretProvider }}
         csi:
@@ -131,3 +150,4 @@ spec:
         secret:
           secretName: {{ .Values.presets.db_secretName | quote }}
       {{- end }}
+    {{- end }}

--- a/charts/geoweb-presets-backend/templates/presets-secrets.yaml
+++ b/charts/geoweb-presets-backend/templates/presets-secrets.yaml
@@ -29,7 +29,7 @@ spec:
       objectName: {{ .Values.presets.db_secret }}
     secretName: {{ .Values.presets.db_secretName }}
     type: Opaque
-{{- else }}
+{{- else if not .Values.presets.db.useZalandoOperatorDb }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/geoweb-presets-backend/values.yaml
+++ b/charts/geoweb-presets-backend/values.yaml
@@ -10,7 +10,7 @@ presets:
   PRESETS_PORT_HTTP: 8080
   DEPLOY_ENVIRONMENT: open
   postStartCommand: bin/admin.sh
-  db_secret: cG9zdGdyZXNxbDovL3Bvc3RncmVzOnBvc3RncmVzQGxvY2FsaG9zdDo1NDMyL3ByZXNldHM=
+  db_secret: cG9zdGdyZXNxbDovL2dlb3dlYjpwb3N0Z3Jlc0Bsb2NhbGhvc3Q6NTQzMi9wcmVzZXRz
   db_secretName: presets-db
   db_secretType: secretsmanager
   spcName: presets-spc
@@ -66,12 +66,20 @@ presets:
       failureThreshold: 1
   db:
     enableDefaultDb: true
-    name: postgres
+    useZalandoOperatorDb: false
+    name: presets-db
     image: postgres
     port: 5432
     POSTGRES_DB: presets
-    POSTGRES_USER: postgres
+    POSTGRES_USER: geoweb
     POSTGRES_PASSWORD: postgres
+    POSTGRES_VERSION: 15
+    numberOfInstances: 1
+    instanceSize: 100Mi
+    zalandoTeamId: geoweb
+    enableLogicalBackup: true
+    cleanInstall: true
+    backupTimestamp: "2030-01-01T00:00:00+00:00"
   useCustomWorkspacePresets: false
   customWorkspacePresetLocation: local
   volumeAccessMode: ReadOnlyMany

--- a/charts/geoweb-taf-backend/Chart.yaml
+++ b/charts/geoweb-taf-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-taf-backend/README.md
+++ b/charts/geoweb-taf-backend/README.md
@@ -52,6 +52,17 @@ taf:
   awsDefaultRegion: <AWS_DEFAULT_REGION>
 ```
 
+* Using Zalando Operator Database
+```yaml
+taf:
+  url: geoweb.example.com
+  db:
+    enableDefaultDb: false
+    useZalandoOperatorDb: true
+    cleanInstall: false # Add this line only after first install
+    backupBucket: s3://<S3-bucket-name>/
+```
+
 # Testing the Chart
 Execute the following for testing the chart:
 

--- a/charts/geoweb-taf-backend/templates/taf-database.yaml
+++ b/charts/geoweb-taf-backend/templates/taf-database.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.taf.db.useZalandoOperatorDb }}
+apiVersion: "acid.zalan.do/v1"
+kind: postgresql
+metadata:
+  name: {{ .Values.taf.db.name }}
+spec:
+  teamId: {{ .Values.taf.db.zalandoTeamId }}
+  volume:
+    size: {{ .Values.taf.db.instanceSize }}
+  numberOfInstances: {{ .Values.taf.db.numberOfInstances }}
+  users:
+    {{ .Values.taf.db.POSTGRES_USER }}:
+    - superuser
+    - createdb
+  databases:
+    {{ .Values.taf.db.POSTGRES_DB }}: {{ .Values.taf.db.POSTGRES_USER }}
+  postgresql:
+    version: {{ .Values.taf.db.POSTGRES_VERSION | quote }}
+  enableLogicalBackup: {{ .Values.taf.db.enableLogicalBackup }}
+  {{- if not .Values.taf.db.cleanInstall }}
+  clone:
+    cluster: {{ .Values.taf.db.name | quote }}
+    timestamp: {{ .Values.taf.db.backupTimestamp | quote }}
+    s3_wal_path: {{ .Values.taf.db.backupBucket | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/geoweb-taf-backend/templates/taf-deployment.yaml
+++ b/charts/geoweb-taf-backend/templates/taf-deployment.yaml
@@ -111,19 +111,37 @@ spec:
         readinessProbe: {{ toYaml .Values.taf.placeholder.readinessProbe | nindent 10 }}
       {{- end }}
         env:
+      {{- if .Values.taf.db.useZalandoOperatorDb }}
+        - name: PG_PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.taf.db.POSTGRES_USER }}.{{ .Values.taf.db.name }}.credentials.postgresql.acid.zalan.do
+              key: password
+        - name: PG_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.taf.db.POSTGRES_USER }}.{{ .Values.taf.db.name }}.credentials.postgresql.acid.zalan.do
+              key: username
+      {{- end }}
         - name: AVIATION_TAF_BACKEND_DB
+        {{- if .Values.taf.db.useZalandoOperatorDb }}
+          value: "postgresql://$(PG_USER):$(PG_PASS)@{{ .Values.taf.db.name }}:5432/{{ .Values.taf.db.POSTGRES_DB }}"
+        {{- else }}
           valueFrom:
             secretKeyRef:
               name: {{ .Values.taf.db_secretName }}
               key: AVIATION_TAF_BACKEND_DB
+        {{- end }}
       {{- if .Values.taf.placeholder.TAFPLACEHOLDER_KEEPRUNNING }}
         - name: TAFPLACEHOLDER_KEEPRUNNING
           value: {{ .Values.taf.placeholder.TAFPLACEHOLDER_KEEPRUNNING | quote }}
       {{- end }}
+      {{- if not .Values.taf.db.useZalandoOperatorDb }}
         volumeMounts:
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
           readOnly: true
+      {{- end }}
       - name: {{ .Values.taf.messageconverter.name }}
         image: {{ .Values.taf.messageconverter.registry }}:{{ .Values.taf.messageconverter.version }}
       {{- if .Values.taf.imagePullPolicy }}

--- a/charts/geoweb-taf-backend/templates/taf-deployment.yaml
+++ b/charts/geoweb-taf-backend/templates/taf-deployment.yaml
@@ -65,15 +65,33 @@ spec:
         - configMapRef:
             name: {{ .Values.taf.name }}
         env:
+      {{- if .Values.taf.db.useZalandoOperatorDb }}
+        - name: PG_PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.taf.db.POSTGRES_USER }}.{{ .Values.taf.db.name }}.credentials.postgresql.acid.zalan.do
+              key: password
+        - name: PG_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.taf.db.POSTGRES_USER }}.{{ .Values.taf.db.name }}.credentials.postgresql.acid.zalan.do
+              key: username
+      {{- end }}
         - name: AVIATION_TAF_BACKEND_DB
+        {{- if .Values.taf.db.useZalandoOperatorDb }}
+          value: "postgresql://$(PG_USER):$(PG_PASS)@{{ .Values.taf.db.name }}:5432/{{ .Values.taf.db.POSTGRES_DB }}"
+        {{- else }}
           valueFrom:
             secretKeyRef:
               name: {{ .Values.taf.db_secretName }}
               key: AVIATION_TAF_BACKEND_DB
+        {{- end }}
+      {{- if not .Values.taf.db.useZalandoOperatorDb }}
         volumeMounts:
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
           readOnly: true
+      {{- end }}
       {{- if and .Values.taf.useCustomConfigurationFiles }}
         - mountPath: {{ .Values.taf.customConfigurationMountPath }}
           name: {{ .Values.taf.name }}-volume
@@ -192,6 +210,7 @@ spec:
           claimName: {{ .Values.taf.name }}-claim
       {{- end }}
     {{- end }}
+    {{- if not .Values.taf.db.useZalandoOperatorDb }}
       - name: secrets-store-inline
       {{- if .Values.secretProvider }}
         csi:
@@ -203,6 +222,7 @@ spec:
         secret:
           secretName: {{ .Values.taf.db_secretName | quote }}
       {{- end }}
+    {{- end }}
       - name: publisher-volume
       {{- if .Values.taf.publisher.volumeOptions }}
         {{- toYaml .Values.taf.publisher.volumeOptions | nindent 8 }}

--- a/charts/geoweb-taf-backend/templates/taf-secrets.yaml
+++ b/charts/geoweb-taf-backend/templates/taf-secrets.yaml
@@ -29,7 +29,7 @@ spec:
       objectName: {{ .Values.taf.db_secret }}
     secretName: {{ .Values.taf.db_secretName }}
     type: Opaque
-{{- else }}
+{{- else if not .Values.taf.db.useZalandoOperatorDb }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/geoweb-taf-backend/values.yaml
+++ b/charts/geoweb-taf-backend/values.yaml
@@ -7,7 +7,7 @@ taf:
   path: /taf/(.*)
   svcPort: 80
   replicas: 1
-  db_secret: cG9zdGdyZXNxbDovL3Bvc3RncmVzOnBvc3RncmVzQGxvY2FsaG9zdDo1NDMyL3RhZg==
+  db_secret: cG9zdGdyZXNxbDovL2dlb3dlYjpwb3N0Z3Jlc0Bsb2NhbGhvc3Q6NTQzMi90YWY=
   db_secretName: taf-db
   db_secretType: secretsmanager
   spcName: taf-spc
@@ -150,12 +150,20 @@ taf:
       failureThreshold: 1
   db:
     enableDefaultDb: true
-    name: postgres
+    useZalandoOperatorDb: false
+    name: taf-db
     image: postgres
     port: 5432
     POSTGRES_DB: taf
-    POSTGRES_USER: postgres
+    POSTGRES_USER: geoweb
     POSTGRES_PASSWORD: postgres
+    POSTGRES_VERSION: 15
+    numberOfInstances: 1
+    instanceSize: 100Mi
+    zalandoTeamId: geoweb
+    enableLogicalBackup: true
+    cleanInstall: true
+    backupTimestamp: "2030-01-01T00:00:00+00:00"
   useCustomConfigurationFiles: false
   customConfigurationLocation: local
   customConfigurationMountPath: /app/custom

--- a/charts/geoweb-warnings-backend/Chart.yaml
+++ b/charts/geoweb-warnings-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-warnings-backend/README.md
+++ b/charts/geoweb-warnings-backend/README.md
@@ -27,6 +27,17 @@ warnings:
   db_secret: base64_encoded_postgresql_connection_string
 ```
 
+* Using Zalando Operator Database
+```yaml
+warnings:
+  url: geoweb.example.com
+  db:
+    enableDefaultDb: false
+    useZalandoOperatorDb: true
+    cleanInstall: false # Add this line only after first install
+    backupBucket: s3://<S3-bucket-name>/
+```
+
 # Testing the Chart
 Execute the following for testing the chart:
 

--- a/charts/geoweb-warnings-backend/templates/warnings-database.yaml
+++ b/charts/geoweb-warnings-backend/templates/warnings-database.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.warnings.db.useZalandoOperatorDb }}
+apiVersion: "acid.zalan.do/v1"
+kind: postgresql
+metadata:
+  name: {{ .Values.warnings.db.name }}
+spec:
+  teamId: {{ .Values.warnings.db.zalandoTeamId }}
+  volume:
+    size: {{ .Values.warnings.db.instanceSize }}
+  numberOfInstances: {{ .Values.warnings.db.numberOfInstances }}
+  users:
+    {{ .Values.warnings.db.POSTGRES_USER }}:
+    - superuser
+    - createdb
+  databases:
+    {{ .Values.warnings.db.POSTGRES_DB }}: {{ .Values.warnings.db.POSTGRES_USER }}
+  postgresql:
+    version: {{ .Values.warnings.db.POSTGRES_VERSION | quote }}
+  enableLogicalBackup: {{ .Values.warnings.db.enableLogicalBackup }}
+  {{- if not .Values.warnings.db.cleanInstall }}
+  clone:
+    cluster: {{ .Values.warnings.db.name | quote }}
+    timestamp: {{ .Values.warnings.db.backupTimestamp | quote }}
+    s3_wal_path: {{ .Values.warnings.db.backupBucket | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/geoweb-warnings-backend/templates/warnings-deployment.yaml
+++ b/charts/geoweb-warnings-backend/templates/warnings-deployment.yaml
@@ -69,6 +69,7 @@ spec:
             secretKeyRef:
               name: {{ .Values.warnings.db_secretName }}
               key: WARNINGS_BACKEND_DB
+        {{- end }}
       {{- if not .Values.warnings.db.useZalandoOperatorDb }}
         volumeMounts:
         - name: secrets-store-inline

--- a/charts/geoweb-warnings-backend/templates/warnings-deployment.yaml
+++ b/charts/geoweb-warnings-backend/templates/warnings-deployment.yaml
@@ -49,15 +49,32 @@ spec:
         - configMapRef:
             name: {{ .Values.warnings.name }}
         env:
+      {{- if .Values.warnings.db.useZalandoOperatorDb }}
+        - name: PG_PASS
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.warnings.db.POSTGRES_USER }}.{{ .Values.warnings.db.name }}.credentials.postgresql.acid.zalan.do
+              key: password
+        - name: PG_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.warnings.db.POSTGRES_USER }}.{{ .Values.warnings.db.name }}.credentials.postgresql.acid.zalan.do
+              key: username
+      {{- end }}
         - name: WARNINGS_BACKEND_DB
+        {{- if .Values.warnings.db.useZalandoOperatorDb }}
+          value: "postgresql://$(PG_USER):$(PG_PASS)@{{ .Values.warnings.db.name }}:5432/{{ .Values.warnings.db.POSTGRES_DB }}"
+        {{- else }}
           valueFrom:
             secretKeyRef:
               name: {{ .Values.warnings.db_secretName }}
               key: WARNINGS_BACKEND_DB
+      {{- if not .Values.warnings.db.useZalandoOperatorDb }}
         volumeMounts:
         - name: secrets-store-inline
           mountPath: "/mnt/secrets-store"
           readOnly: true
+      {{- end }}
       - name: {{ .Values.warnings.nginx.name }}
         image: {{ .Values.warnings.nginx.registry }}:{{ default .Chart.AppVersion .Values.versions.warnings }}
       {{- if .Values.warnings.imagePullPolicy }}
@@ -91,6 +108,7 @@ spec:
             value: {{ .Values.warnings.db.POSTGRES_PASSWORD }}
       {{- end }}
       volumes:
+    {{- if not .Values.warnings.db.useZalandoOperatorDb }}
       - name: secrets-store-inline
       {{- if .Values.secretProvider }}
         csi:
@@ -102,3 +120,4 @@ spec:
         secret:
           secretName: {{ .Values.warnings.db_secretName | quote }}
       {{- end }}
+    {{- end }}

--- a/charts/geoweb-warnings-backend/templates/warnings-secrets.yaml
+++ b/charts/geoweb-warnings-backend/templates/warnings-secrets.yaml
@@ -29,7 +29,7 @@ spec:
       objectName: {{ .Values.warnings.db_secret }}
     secretName: {{ .Values.warnings.db_secretName }}
     type: Opaque
-{{- else }}
+{{- else if not .Values.warnings.db.useZalandoOperatorDb }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/geoweb-warnings-backend/values.yaml
+++ b/charts/geoweb-warnings-backend/values.yaml
@@ -9,7 +9,7 @@ warnings:
   replicas: 1
   WARNINGS_PORT_HTTP: 8080
   postStartCommand: bin/admin.sh
-  db_secret: cG9zdGdyZXNxbDovL3Bvc3RncmVzOnBvc3RncmVzQGxvY2FsaG9zdDo1NDMyL3dhcm5pbmdz
+  db_secret: cG9zdGdyZXNxbDovL2dlb3dlYjpwb3N0Z3Jlc0Bsb2NhbGhvc3Q6NTQzMi93YXJuaW5ncw==
   db_secretName: warnings-db
   db_secretType: secretsmanager
   spcName: warnings-spc
@@ -65,12 +65,20 @@ warnings:
       failureThreshold: 1
   db:
     enableDefaultDb: true
-    name: postgres
+    useZalandoOperatorDb: false
+    name: warnings-db
     image: postgres
     port: 5432
     POSTGRES_DB: warnings
-    POSTGRES_USER: postgres
+    POSTGRES_USER: geoweb
     POSTGRES_PASSWORD: postgres
+    POSTGRES_VERSION: 15
+    numberOfInstances: 1
+    instanceSize: 100Mi
+    zalandoTeamId: geoweb
+    enableLogicalBackup: true
+    cleanInstall: true
+    backupTimestamp: "2030-01-01T00:00:00+00:00"
 
 ingress:
   name: nginx-ingress-controller


### PR DESCRIPTION
Add support for using Zalando databases for geoweb presets, taf and warnings backends. This is basically copy from earlier PR where support was added to opmet-backend, so copying the descriptions from there: https://github.com/fmidev/helm-charts/pull/39

Added option to use Zalando Operator Postgres database instead of connection string to external database
* If useZalandoOperatorDb == true
  * Add postgresql resource
  * Use generated username & password created by postgresql resource to automatically set PRESETS_BACKEND_DB, AVIATION_TAF_BACKEND_DB and WARNINGS_BACKEND_DB instead of using db_secret
  * Don't generate db secret using db_secret
* If useZalandoOperatorDb == false
  * No changes except for changed default database name (and encoded database string)
* cleanInstall determines if database is started clean or restored from a backup

How to test:
* Code review
* Applications are deployed and used in https://terraform.opengeoweb.com instance, and the deployed backends are running at https://terraform.opengeoweb.com/taf, https://terraform.opengeoweb.com/presets and https://terraform.opengeoweb.com/warnings and the deployments can be inspected in test-geoweb cluster @intlgeoweb AWS account!

Closes https://gitlab.com/opengeoweb/fmi/fmi-aws-config/-/issues/118 & https://gitlab.com/opengeoweb/fmi/fmi-aws-config/-/issues/196 & https://gitlab.com/opengeoweb/fmi/fmi-aws-config/-/issues/197

