### PR TITLE
Update opmet-backend version

### DIFF
--- a/charts/geoweb-opmet-backend/Chart.yaml
+++ b/charts/geoweb-opmet-backend/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.0
+version: 3.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.7.0"
+appVersion: "v2.9.0"
 
 maintainers:
   - name: Jusaa

--- a/charts/geoweb-opmet-backend/values.yaml
+++ b/charts/geoweb-opmet-backend/values.yaml
@@ -93,7 +93,7 @@ opmet:
   nginx:
     name: opmet-nginx
     registry: registry.gitlab.com/opengeoweb/backend-services/auth-backend/auth-backend
-    version: "v0.1.1"
+    version: "v0.2.0"
     ENABLE_SSL: "FALSE"
     NGINX_PORT_HTTP: 80
     NGINX_PORT_HTTPS: 443


### PR DESCRIPTION
Requires this [MR](https://gitlab.com/opengeoweb/backend-services/opmet-backend/-/merge_requests/93) and new release v2.9.0 (opmet-backend)