### PR TITLE
added js profiling header to enable sentry profiling

### DIFF
--- a/charts/geoweb-frontend/Chart.yaml
+++ b/charts/geoweb-frontend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.4.0
+version: 3.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-frontend/values.yaml
+++ b/charts/geoweb-frontend/values.yaml
@@ -54,6 +54,9 @@ frontend:
 ingress:
   name: nginx-ingress-controller
   rules: |
+    if ($request_uri ~* \.(js)) {
+      add_header "Document-Policy", "js-profiling";
+    }
     if ($request_uri ~* \.(json)) {
       add_header Cache-Control "no-cache";
     }

--- a/charts/geoweb-frontend/values.yaml
+++ b/charts/geoweb-frontend/values.yaml
@@ -55,7 +55,7 @@ ingress:
   name: nginx-ingress-controller
   rules: |
     if ($request_uri ~* \.(js)) {
-      add_header "Document-Policy", "js-profiling";
+      add_header "Document-Policy" "js-profiling";
     }
     if ($request_uri ~* \.(json)) {
       add_header Cache-Control "no-cache";

--- a/charts/geoweb-frontend/values.yaml
+++ b/charts/geoweb-frontend/values.yaml
@@ -55,7 +55,7 @@ ingress:
   name: nginx-ingress-controller
   rules: |
     if ($request_uri ~* \.(js)) {
-      add_header "Document-Policy" "js-profiling";
+      add_header Document-Policy "js-profiling";
     }
     if ($request_uri ~* \.(json)) {
       add_header Cache-Control "no-cache";


### PR DESCRIPTION
- added js profiling header to enable Sentry profiling
- With this, if Sentry is enabled in frontend, the profiling functionality should work. (It is currently configured in frontend code in which envionment Sentry is initialized. The current environments are `acc.opengeoweb.com` and `acc-geoweb.fmi.fi`)