### PR TITLE
Removed GW_INFRA_BASE_URL

### DIFF
--- a/charts/geoweb-frontend/Chart.yaml
+++ b/charts/geoweb-frontend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.8.1
+version: 3.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-frontend/README.md
+++ b/charts/geoweb-frontend/README.md
@@ -140,7 +140,6 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 | `frontend.env.GW_AUTH_LOGOUT_URL` | Url to redirect when logging out | `"http://localhost:5400"` |
 | `frontend.env.GW_AUTH_TOKEN_URL` | - | `https://gitlab.com/oauth/token` |
 | `frontend.env.GW_AUTH_LOGIN_URL` | Url to redirect when logging in | `https://gitlab.com/oauth/authorize?client_id={client_id}&response_type=code&scope=email+openid+read_repository+read_api&redirect_uri={app_url}/code&state={state}&code_challenge={code_challenge}&code_challenge_method=S256` |
-| `frontend.env.GW_INFRA_BASE_URL` | - | `https://api.opengeoweb.com` |
 | `frontend.env.GW_INITIAL_PRESETS_FILENAME` | Filename to fetch initial presets | `initialPresets.json` |
 | `frontend.env.GW_CAP_CONFIGURATION_FILENAME` | Filename to fetch CAP Warnings configured feeds | `capWarningPresets.json` |
 | `frontend.env.GW_TIMESERIES_CONFIGURATION_FILENAME` | Filename to fetch TimeSeries preset locations | `timeSeriesPresetLocations.json` |
@@ -177,6 +176,7 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 | Chart version | frontend version |
 |---------------|------------------|
 | 3.9.0         | 9.14.0           |
+| 3.8.1         | 9.14.0           |
 | 3.4.0         | 9.9.0            |
 | 3.3.0         | 9.6.0            |
 | 3.2.0         | 9.5.0            |

--- a/charts/geoweb-frontend/templates/geoweb-configmap.yaml
+++ b/charts/geoweb-frontend/templates/geoweb-configmap.yaml
@@ -16,9 +16,6 @@ data:
 {{- if .Values.frontend.env.GW_AUTH_LOGIN_URL }}
   GW_AUTH_LOGIN_URL: {{ .Values.frontend.env.GW_AUTH_LOGIN_URL | quote }}
 {{- end }}
-{{- if .Values.frontend.env.GW_INFRA_BASE_URL }}
-  GW_INFRA_BASE_URL: {{ .Values.frontend.env.GW_INFRA_BASE_URL | quote }}
-{{- end }}
 {{- if .Values.frontend.env.GW_CAP_BASE_URL }}
   GW_CAP_BASE_URL: {{ .Values.frontend.env.GW_CAP_BASE_URL | quote }}
 {{- end }}

--- a/charts/geoweb-frontend/values.yaml
+++ b/charts/geoweb-frontend/values.yaml
@@ -38,7 +38,6 @@ frontend:
     GW_AUTH_LOGOUT_URL: "{app_url}"
     GW_AUTH_TOKEN_URL: https://gitlab.com/oauth/token
     GW_AUTH_LOGIN_URL: https://gitlab.com/oauth/authorize?client_id={client_id}&response_type=code&scope=email+openid+read_repository+read_api&redirect_uri={app_url}/code&state={state}&code_challenge={code_challenge}&code_challenge_method=S256
-    GW_INFRA_BASE_URL: https://api.opengeoweb.com
     GW_FEATURE_FORCE_AUTHENTICATION: false
     GW_FEATURE_MODULE_SPACE_WEATHER: false
     GW_FEATURE_MENU_FEEDBACK: false


### PR DESCRIPTION
`GW_INFRA_BASE_URL` [was removed](https://gitlab.com/opengeoweb/opengeoweb/-/merge_requests/3340) in frontend version v9.9.0. Removed it from the chart.