### PR TITLE
Made ingress TLS section configurable

### DIFF
--- a/charts/geoweb-cap-backend/Chart.yaml
+++ b/charts/geoweb-cap-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.7
+version: 1.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-cap-backend/README.md
+++ b/charts/geoweb-cap-backend/README.md
@@ -57,5 +57,6 @@ The following table lists the configurable parameters of the CAP backend chart a
 | `cap.livenessProbe` | Configure libenessProbe | see defaults from `values.yaml` |
 | `cap.readinessProbe` | Configure readinessProbe | see defaults from `values.yaml` |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |
+| `ingress.tls` | TLS configuration section for the ingress | |
 | `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | `nginx` |
 | `ingress.customAnnotations` | Custom annotations for ingress, for example <pre>customAnnotations:<br>  traefik.annotation: exampleValue</pre> Overrides default nginx annotations if set | |

--- a/charts/geoweb-cap-backend/templates/cap-ingress.yaml
+++ b/charts/geoweb-cap-backend/templates/cap-ingress.yaml
@@ -18,6 +18,9 @@ spec:
 {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
 {{- end }}
+{{- if .Values.ingress.tls }}
+  tls: {{ toYaml .Values.ingress.tls | nindent 4 }}
+{{- end }}
   rules:
     - host: {{ .Values.cap.url }}
       http:

--- a/charts/geoweb-frontend/Chart.yaml
+++ b/charts/geoweb-frontend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.9.0
+version: 3.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-frontend/README.md
+++ b/charts/geoweb-frontend/README.md
@@ -168,6 +168,7 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 | `frontend.awsDefaultRegion` | Region where your S3 bucket is located | |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |
 | `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | `nginx` |
+| `ingress.tls` | TLS configuration section for the ingress | |
 | `ingress.rules` | Extra nginx configuration rules, like cache headers | See reference in `values.yaml` |
 | `ingress.customAnnotations` | Custom annotations for ingress, for example <pre>customAnnotations:<br>  traefik.annotation: exampleValue</pre> Overrides default nginx annotations and `frontend.auth_secret`, `frontend.auth_secretName` and `ingress.rules` can't be used if set | |
 

--- a/charts/geoweb-frontend/templates/geoweb-ingress.yaml
+++ b/charts/geoweb-frontend/templates/geoweb-ingress.yaml
@@ -26,6 +26,9 @@ spec:
 {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
 {{- end }}
+{{- if .Values.ingress.tls }}
+  tls: {{ toYaml .Values.ingress.tls | nindent 4 }}
+{{- end }}
   rules:
     - host: {{ .Values.frontend.url }}
       http:

--- a/charts/geoweb-opmet-backend/Chart.yaml
+++ b/charts/geoweb-opmet-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.3.1
+version: 3.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-opmet-backend/README.md
+++ b/charts/geoweb-opmet-backend/README.md
@@ -114,6 +114,7 @@ The following table lists the configurable parameters of the Opmet backend chart
 | `ingress.customAnnotations`                   | Custom annotations for ingress, for example <pre>customAnnotations:<br>  traefik.annotation: exampleValue</pre> Overrides default nginx annotations if set |                                                                                              |
 | `ingress.ingressClassName`                    | Set ingressClassName parameter to not use default ingressClass | `nginx`                                                                                      |
 | `ingress.name`                                | Name of the ingress controller in use | `nginx-ingress-controller`                                                                   |
+| `ingress.tls`                                 | TLS configuration section for the ingress | |
 | `opmet.awsAccessKeyId`                        | AWS_ACCESS_KEY_ID for authenticating to S3 |                                                                                              |
 | `opmet.awsAccessKeySecret`                    | AWS_SECRET_ACCESS_KEY for authenticating to S3 |                                                                                              |
 | `opmet.awsDefaultRegion`                      | Region where your S3 bucket is located |                                                                                              |

--- a/charts/geoweb-opmet-backend/templates/opmet-ingress.yaml
+++ b/charts/geoweb-opmet-backend/templates/opmet-ingress.yaml
@@ -18,6 +18,9 @@ spec:
 {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
 {{- end }}
+{{- if .Values.ingress.tls }}
+  tls: {{ toYaml .Values.ingress.tls | nindent 4 }}
+{{- end }}
   rules:
     - host: {{ .Values.opmet.url }}
       http:

--- a/charts/geoweb-presets-backend/Chart.yaml
+++ b/charts/geoweb-presets-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.9.0
+version: 2.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-presets-backend/README.md
+++ b/charts/geoweb-presets-backend/README.md
@@ -174,5 +174,6 @@ The following table lists the configurable parameters of the Presets backend cha
 | `presets.awsAccessKeySecret` | AWS_SECRET_ACCESS_KEY for authenticating to S3 | |
 | `presets.awsDefaultRegion` | Region where your S3 bucket is located | |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |
+| `ingress.tls` | TLS configuration section for the ingress | |
 | `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | `nginx` |
 | `ingress.customAnnotations` | Custom annotations for ingress, for example <pre>customAnnotations:<br>  traefik.annotation: exampleValue</pre> Overrides default nginx annotations if set | |

--- a/charts/geoweb-presets-backend/templates/presets-ingress.yaml
+++ b/charts/geoweb-presets-backend/templates/presets-ingress.yaml
@@ -18,6 +18,9 @@ spec:
 {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
 {{- end }}
+{{- if .Values.ingress.tls }}
+  tls: {{ toYaml .Values.ingress.tls | nindent 4 }}
+{{- end }}
   rules:
     - host: {{ .Values.presets.url }}
       http:

--- a/charts/geoweb-taf-backend/Chart.yaml
+++ b/charts/geoweb-taf-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-taf-backend/README.md
+++ b/charts/geoweb-taf-backend/README.md
@@ -169,5 +169,6 @@ The following table lists the configurable parameters of the Taf backend chart a
 | `taf.db.POSTGRES_USER` | Default postgres database user | `postgres` |
 | `taf.db.POSTGRES_PASSWORD` | Default postgres database password | `postgres` |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |
+| `ingress.tls` | TLS configuration section for the ingress | |
 | `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | |
 | `ingress.customAnnotations` | Custom annotations for ingress, for example <pre>customAnnotations:<br>  traefik.annotation: exampleValue</pre> Overrides default nginx annotations if set | |

--- a/charts/geoweb-taf-backend/templates/taf-ingress.yaml
+++ b/charts/geoweb-taf-backend/templates/taf-ingress.yaml
@@ -18,6 +18,9 @@ spec:
 {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
 {{- end }}
+{{- if .Values.ingress.tls }}
+  tls: {{ toYaml .Values.ingress.tls | nindent 4 }}
+{{- end }}
   rules:
     - host: {{ .Values.taf.url }}
       http:

--- a/charts/geoweb-warnings-backend/Chart.yaml
+++ b/charts/geoweb-warnings-backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-warnings-backend/README.md
+++ b/charts/geoweb-warnings-backend/README.md
@@ -111,6 +111,7 @@ The following table lists the configurable parameters of the Warnings backend ch
 | `warnings.db.POSTGRES_USER` | Default postgres database user | `postgres` |
 | `warnings.db.POSTGRES_PASSWORD` | Default postgres database password | `postgres` |
 | `ingress.name` | Name of the ingress controller in use | `nginx-ingress-controller` |
+| `ingress.tls` | TLS configuration section for the ingress | |
 | `ingress.ingressClassName` | Set ingressClassName parameter to not use default ingressClass | `nginx` |
 | `ingress.customAnnotations` | Custom annotations for ingress, for example <pre>customAnnotations:<br>  traefik.annotation: exampleValue</pre> Overrides default nginx annotations if set | |
 

--- a/charts/geoweb-warnings-backend/templates/warnings-ingress.yaml
+++ b/charts/geoweb-warnings-backend/templates/warnings-ingress.yaml
@@ -18,6 +18,9 @@ spec:
 {{- if .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}
 {{- end }}
+{{- if .Values.ingress.tls }}
+  tls: {{ toYaml .Values.ingress.tls | nindent 4 }}
+{{- end }}
   rules:
     - host: {{ .Values.warnings.url }}
       http:


### PR DESCRIPTION
Closes https://gitlab.com/opengeoweb/fmi/fmi-aws-config/-/issues/276

To test:
- Add something like
```
ingress:
  tls:
    - hosts:
        - example.com
      secretName: geoweb-tls
```
to a values.yaml file for one of the charts where this change applies.

Then do a `helm template . --debug` and see that the produced ingress object looks good.