### PR TITLE
Start postgresql server with ssl on

### DIFF
--- a/charts/fmi-radon/Chart.yaml
+++ b/charts/fmi-radon/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fmi-radon/README.md
+++ b/charts/fmi-radon/README.md
@@ -17,7 +17,15 @@ provided by the cloud provider (e.g. gp3-csi for aws).
 ### Secrets
 
 Necessary passwords for the database users need to be created before creating
-the chart. Set the passwords to templates/secrets.yaml before installation.
+the chart. Set the base64 encoded passwords to templates/secrets.yaml before
+installation.
+
+Generate self-signed certificates for the server with these
+[instructions](https://www.postgresql.org/docs/15/ssl-tcp.html). 
+
+```bash
+oc create secret generic radon-ssl --from-file=server.key=ssl/server.key --from-file=server.crt=ssl/server.crt
+```
 
 ### [SCC policy](https://docs.openshift.com/container-platform/3.11/admin_guide/manage_scc.html)
 

--- a/charts/fmi-radon/templates/configmap.yaml
+++ b/charts/fmi-radon/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: custom-postgresql-config
+data:
+  postgresql.conf: |
+    listen_addresses = '*'
+    ssl = on
+    ssl_cert_file = '/etc/postgresql/ssl/server.crt'
+    ssl_key_file = '/etc/postgresql/ssl/server.key'
+    ssl_ciphers = 'HIGH:MEDIUM:+3DES:!aNULL'

--- a/charts/fmi-radon/templates/secrets.yaml
+++ b/charts/fmi-radon/templates/secrets.yaml
@@ -9,3 +9,14 @@ metadata:
   name: db-credentials
   namespace: {{ .Release.Name }}
 type: Opaque
+---
+apiVersion: v1
+data:
+  server.crt: pass
+  server.key: pass
+kind: Secret
+metadata:
+  name: radon-ssl
+  namespace: {{ .Release.Name }}
+type: Opaque
+

--- a/charts/fmi-radon/templates/statefulset.yaml
+++ b/charts/fmi-radon/templates/statefulset.yaml
@@ -34,6 +34,7 @@ spec:
           {{ end -}}
           ports:
             - containerPort: 5432
+          args: ["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"]
           env:
             - name: PGDATA
               value: {{ .Values.storage.mountPath }}/data
@@ -61,7 +62,19 @@ spec:
             - mountPath: {{ .Values.storage.mountPath }}
               name: radondb
               readOnly: false
+            - name: custom-config
+              mountPath: /etc/postgresql
+            - name: radon-ssl
+              mountPath: /etc/postgresql/ssl
+              readOnly: true
       volumes:
         - name: radondb
           persistentVolumeClaim:
             claimName: {{ .Values.storage.persistent.claim.name }}-{{ .Values.environment }}
+        - name: custom-config
+          configMap:
+            name: custom-postgresql-config
+        - name: radon-ssl
+          secret:
+            secretName: radon-ssl
+            defaultMode: 0600


### PR DESCRIPTION
Created custom postgresql.conf -configuration to override the defaults. Certificates are self-signed and mounted as a secret manually. 

SSL mode was set on because among other things the scripts in radon_tables -suite requires it to be on.