### PR TITLE
Workflow for installing modified chart to a openshift cluster

### DIFF
--- a/.github/workflows/openshift-install.yml
+++ b/.github/workflows/openshift-install.yml
@@ -1,0 +1,64 @@
+name: Install chart to Openshift
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.14.0
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: Print oc version
+        run:  oc version
+
+      - name: Login to OpenShift
+        env:
+          OPENSHIFT_SERVER_URL: ${{ secrets.OPENSHIFT_SERVER_URL }}
+          OPENSHIFT_API_TOKEN: ${{ secrets.OPENSHIFT_API_TOKEN }}
+        run: |
+          oc login $OPENSHIFT_SERVER_URL --token=$OPENSHIFT_API_TOKEN
+          oc status
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Custom FMI code not included in the reference implementation (https://github.com/marketplace/actions/helm-chart-testing)
+      - name: Add repos for all dependencies (only for the changed)
+        run: |
+          for chart_dir in $(ct list-changed --target-branch ${{ github.event.repository.default_branch }}); do
+            echo "processing changed chart in '${chart_dir}'" 1>&2
+            cd "${chart_dir}"
+            if [[ -e "./Chart.lock" ]]; then
+              yq --indent 0 '.dependencies | map(["helm", "repo", "add", .name, .repository] | join(" ")) | .[]' "./Chart.lock" | sh --;
+            else
+              echo "no Chart.lock found, skip repo addition" 1>&2
+            fi
+            cd - &> /dev/null
+          done
+
+      - name: Run chart-testing (install to openshift)
+        env:
+          OPENSHIFT_NAMESPACE: ${{ secrets.NAMESPACE }}
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --namespace $OPENSHIFT_NAMESPACE

--- a/.github/workflows/openshift-install.yml
+++ b/.github/workflows/openshift-install.yml
@@ -1,64 +1,64 @@
 name: Install chart to Openshift
 
-on: pull_request
+on: pull_request # yamllint disable-line rule:truthy
 
 jobs:
   lint-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.14.0
+    - name: Set up Helm
+      uses: azure/setup-helm@v3
+      with:
+        version: v3.14.0
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.12'
-          check-latest: true
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+        check-latest: true
 
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+    - name: Set up chart-testing
+      uses: helm/chart-testing-action@v2.6.1
 
-      - name: Print oc version
-        run:  oc version
+    - name: Print oc version
+      run: oc version
 
-      - name: Login to OpenShift
-        env:
-          OPENSHIFT_SERVER_URL: ${{ secrets.OPENSHIFT_SERVER_URL }}
-          OPENSHIFT_API_TOKEN: ${{ secrets.OPENSHIFT_API_TOKEN }}
-        run: |
-          oc login $OPENSHIFT_SERVER_URL --token=$OPENSHIFT_API_TOKEN
-          oc status
+    - name: Login to OpenShift
+      env:
+        OPENSHIFT_SERVER_URL: ${{ secrets.OPENSHIFT_SERVER_URL }}
+        OPENSHIFT_API_TOKEN: ${{ secrets.OPENSHIFT_API_TOKEN }}
+      run: |
+        oc login $OPENSHIFT_SERVER_URL --token=$OPENSHIFT_API_TOKEN
+        oc status
 
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
-          if [[ -n "$changed" ]]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+    - name: Run chart-testing (list-changed)
+      id: list-changed
+      run: |
+        changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+        if [[ -n "$changed" ]]; then
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    # Custom FMI code not included in the reference implementation (https://github.com/marketplace/actions/helm-chart-testing)
+    - name: Add repos for all dependencies (only for the changed)
+      run: |
+        for chart_dir in $(ct list-changed --target-branch ${{ github.event.repository.default_branch }}); do
+          echo "processing changed chart in '${chart_dir}'" 1>&2
+          cd "${chart_dir}"
+          if [[ -e "./Chart.lock" ]]; then
+            yq --indent 0 '.dependencies | map(["helm", "repo", "add", .name, .repository] | join(" ")) | .[]' "./Chart.lock" | sh --;
+          else
+            echo "no Chart.lock found, skip repo addition" 1>&2
           fi
+          cd - &> /dev/null
+        done
 
-      # Custom FMI code not included in the reference implementation (https://github.com/marketplace/actions/helm-chart-testing)
-      - name: Add repos for all dependencies (only for the changed)
-        run: |
-          for chart_dir in $(ct list-changed --target-branch ${{ github.event.repository.default_branch }}); do
-            echo "processing changed chart in '${chart_dir}'" 1>&2
-            cd "${chart_dir}"
-            if [[ -e "./Chart.lock" ]]; then
-              yq --indent 0 '.dependencies | map(["helm", "repo", "add", .name, .repository] | join(" ")) | .[]' "./Chart.lock" | sh --;
-            else
-              echo "no Chart.lock found, skip repo addition" 1>&2
-            fi
-            cd - &> /dev/null
-          done
-
-      - name: Run chart-testing (install to openshift)
-        env:
-          OPENSHIFT_NAMESPACE: ${{ secrets.OPENSHIFT_NAMESPACE }}
-        if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --namespace $OPENSHIFT_NAMESPACE
+    - name: Run chart-testing (install to openshift)
+      env:
+        OPENSHIFT_NAMESPACE: ${{ secrets.OPENSHIFT_NAMESPACE }}
+      if: steps.list-changed.outputs.changed == 'true'
+      run: ct install --target-branch ${{ github.event.repository.default_branch }} --namespace $OPENSHIFT_NAMESPACE

--- a/.github/workflows/openshift-install.yml
+++ b/.github/workflows/openshift-install.yml
@@ -59,6 +59,6 @@ jobs:
 
       - name: Run chart-testing (install to openshift)
         env:
-          OPENSHIFT_NAMESPACE: ${{ secrets.NAMESPACE }}
+          OPENSHIFT_NAMESPACE: ${{ secrets.OPENSHIFT_NAMESPACE }}
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --target-branch ${{ github.event.repository.default_branch }} --namespace $OPENSHIFT_NAMESPACE


### PR DESCRIPTION
Openshift specific resources can't be installed to a basic kubernetes cluster (i.e. kind). In this workflow the runner logs into a openshift cluster and installs the modified charts into there.

Workflow needs the following repository secrets in order to work:
- OPENSHIFT_SERVER_URL (api url of the openshift cluster)
- OPENSHIFT_API_TOKEN (serviceaccount token with edit privileges)
- OPENSHIFT_NAMESPACE (namespace where the test installation is created)

Serviceaccount with required privileges (oc policy add-role-to-user edit -z service-account-name) needs to exist in the openshift. Serviceaccount tokens default lifespan is quite short, so the duration should be set with a flag:
https://access.redhat.com/solutions/7025261


