### PR TITLE
Path to route

### DIFF
--- a/charts/fmi-routes/Chart.yaml
+++ b/charts/fmi-routes/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fmi-routes
 description: Helm chart for defining multiple routes
 type: application
-version: 0.0.9
+version: 0.0.10
 keywords:
   - fmi
   - route

--- a/charts/fmi-routes/Chart.yaml
+++ b/charts/fmi-routes/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fmi-routes
 description: Helm chart for defining multiple routes
 type: application
-version: 0.0.10
+version: 0.10.0
 keywords:
   - fmi
   - route

--- a/charts/fmi-routes/Chart.yaml
+++ b/charts/fmi-routes/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fmi-routes
 description: Helm chart for defining multiple routes
 type: application
-version: 0.10.0
+version: 0.1.0
 keywords:
   - fmi
   - route

--- a/charts/fmi-routes/templates/route.yaml
+++ b/charts/fmi-routes/templates/route.yaml
@@ -15,7 +15,9 @@ metadata:
   {{- end }}
 spec:
   host: {{ $route.host }}
+  {{- if $route.path }}
   path: {{ $route.path }}
+  {{ - end }}
   port:
     targetPort: {{ $route.targetPort  }}
   to:

--- a/charts/fmi-routes/templates/route.yaml
+++ b/charts/fmi-routes/templates/route.yaml
@@ -17,7 +17,7 @@ spec:
   host: {{ $route.host }}
   {{- if $route.path }}
   path: {{ $route.path }}
-  {{ - end }}
+  {{- end }}
   port:
     targetPort: {{ $route.targetPort  }}
   to:

--- a/charts/fmi-routes/templates/route.yaml
+++ b/charts/fmi-routes/templates/route.yaml
@@ -15,6 +15,7 @@ metadata:
   {{- end }}
 spec:
   host: {{ $route.host }}
+  path: {{ $route.path }}
   port:
     targetPort: {{ $route.targetPort  }}
   to:


### PR DESCRIPTION
**Adding path to route allows to determine routes only to certain endpoints / paths**

For example, if a service called `example_service` has multiple `endpoints`, lets call them `/example1` and `/example2`. 

After this merge, we can have different routes with `rules` and `annotations` based on `endpoint`. So we can restrict `example1` to internal usage and allow `example2` to external usage.

```
fmi-routes:
  routes:
    example-service-development-example-route-1:
      enabled: true
      host: example-service.example-internal-host.fmi.fi
      path: /example1
      targetPort: https
      targetService: example-service
      type: external
      tls:
        termination: edge
        
    example-service-development-example-route-2:
      enabled: true
      host: example-service.example-external-host.fmi.fi
      path: /example2
      targetPort: https
      targetService: example-service
      type: external
      tls:
        termination: edge
```

Or

```
fmi-routes:
  routes:
    example-service-development-example-route-1: ## <-- Allows all routes to internal use
      enabled: true
      host: example-service.example-internal-host.fmi.fi
      targetPort: https
      targetService: example-service
      type: external
      tls:
        termination: edge
        
    example-service-development-example-route-2: ## <-- Allows /example2 to external use
      enabled: true
      host: example-service.example-external-host.fmi.fi
      path: /example2
      targetPort: https
      targetService: example-service
      type: external
      tls:
        termination: edge
```