### PR TITLE
Remove the deprecated documentation url from geoweb frontend

### DIFF
--- a/charts/geoweb-frontend/Chart.yaml
+++ b/charts/geoweb-frontend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.14.1
+version: 3.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/geoweb-frontend/Chart.yaml
+++ b/charts/geoweb-frontend/Chart.yaml
@@ -21,7 +21,7 @@ version: 3.14.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v9.28.1"
+appVersion: "v9.29.0"
 
 maintainers:
   - name: Jusaa

--- a/charts/geoweb-frontend/Chart.yaml
+++ b/charts/geoweb-frontend/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.13.1
+version: 3.14.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v9.27.0"
+appVersion: "v9.28.1"
 
 maintainers:
   - name: Jusaa

--- a/charts/geoweb-frontend/README.md
+++ b/charts/geoweb-frontend/README.md
@@ -151,7 +151,6 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 | `frontend.env.GW_FEATURE_MENU_INFO` | Enable Info menu option | `true` |
 | `frontend.env.GW_FEATURE_MENU_VERSION` | Enable Version menu option | `false` |
 | `frontend.env.GW_FEATURE_MENU_FE_VERSION` | Enable FE Version menu option | `true` |
-| `frontend.env.GW_FEATURE_MENU_USER_DOCUMENTATION_URL` | Link to user documentation | |
 | `frontend.env.GW_FEATURE_INITIALIZE_SENTRY` | Enable Sentry in this environment | `true` |
 | `frontend.env.GW_SIGMET_BASE_URL` | Url which the application uses to connect to SIGMET backend | |
 | `frontend.env.GW_AIRMET_BASE_URL` | Url which the application uses to connect to AIRMET backend | |

--- a/charts/geoweb-frontend/templates/geoweb-configmap.yaml
+++ b/charts/geoweb-frontend/templates/geoweb-configmap.yaml
@@ -76,9 +76,6 @@ data:
 {{- if .Values.frontend.env.GW_PRESET_BACKEND_URL }}
   GW_PRESET_BACKEND_URL: {{ .Values.frontend.env.GW_PRESET_BACKEND_URL | quote }}
 {{- end }}
-{{- if .Values.frontend.env.GW_FEATURE_MENU_USER_DOCUMENTATION_URL }}
-  GW_FEATURE_MENU_USER_DOCUMENTATION_URL: {{ .Values.frontend.env.GW_FEATURE_MENU_USER_DOCUMENTATION_URL | quote }}
-{{- end }}
 {{- if .Values.frontend.env.GW_SIGMET_BASE_URL }}
   GW_SIGMET_BASE_URL: {{ .Values.frontend.env.GW_SIGMET_BASE_URL | quote }}
 {{- end }}


### PR DESCRIPTION
Removed the deprecated documentation url env variable. Waiting for the next release and version number.