### PR TITLE
Geoweb taf-backend version updates

### DIFF
--- a/charts/geoweb-taf-backend/Chart.yaml
+++ b/charts/geoweb-taf-backend/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.2.2"
+appVersion: "v2.0.0"
 
 maintainers:
   - name: Jusaa

--- a/charts/geoweb-taf-backend/README.md
+++ b/charts/geoweb-taf-backend/README.md
@@ -30,8 +30,6 @@ taf:
 * Using custom configuration files stored locally
 ```yaml
 taf:
-  env:
-    TAF_CONFIG: custom/config.ini
   url: geoweb.example.com
   useCustomConfigurationFiles: true
   customConfigurationFolderPath: /example/path/
@@ -41,8 +39,6 @@ taf:
 ```yaml
 taf:
   url: geoweb.example.com
-  env:
-    TAF_CONFIG: custom/config.ini
   useCustomConfigurationFiles: true
   customConfigurationLocation: s3
   s3bucketName: example-bucket

--- a/charts/geoweb-taf-backend/README.md
+++ b/charts/geoweb-taf-backend/README.md
@@ -119,7 +119,6 @@ The following table lists the configurable parameters of the Taf backend chart a
 | `taf.env.AVIATION_TAF_PORT_HTTP` | Port used for container | `8000` |
 | `taf.env.GEOWEB_KNMI_AVI_MESSAGESERVICES_HOST` | - | `"localhost:8081"` |
 | `taf.env.AVIATION_TAF_PUBLISH_HOST` | - | `"localhost:8090"` |
-| `taf.env.TAF_CONFIG` | Location of configuration file that is used | `config.ini` |
 | `taf.env.APPLICATION_ROOT_PATH` | Application root path for FastAPI. Generally same as `taf.path` without the wildcard. | `/taf-backend`
 | `taf.useCustomConfigurationFiles` | Use custom configurations | `false` |
 | `taf.customConfigurationLocation` | Where custom configurations are located *(local\|s3)* | `local` |

--- a/charts/geoweb-taf-backend/values.yaml
+++ b/charts/geoweb-taf-backend/values.yaml
@@ -50,7 +50,7 @@ taf:
   messageconverter:
     name: taf-messageconverter
     registry: registry.gitlab.com/opengeoweb/avi-msgconverter/geoweb-knmi-avi-messageservices
-    version: "0.11.1"
+    version: "0.10.1"
     port: 8081
     resources:
       requests:

--- a/charts/geoweb-taf-backend/values.yaml
+++ b/charts/geoweb-taf-backend/values.yaml
@@ -46,12 +46,11 @@ taf:
     GEOWEB_KNMI_AVI_MESSAGESERVICES_HOST: "localhost:8081"
     AVIATION_TAF_PORT_HTTP: 8000
     AVIATION_TAF_PUBLISH_HOST: "localhost:8090"
-    TAF_CONFIG: config.ini
     APPLICATION_ROOT_PATH: "/taf-backend"
   messageconverter:
     name: taf-messageconverter
     registry: registry.gitlab.com/opengeoweb/avi-msgconverter/geoweb-knmi-avi-messageservices
-    version: "0.10.1"
+    version: "0.11.1"
     port: 8081
     resources:
       requests:
@@ -117,7 +116,7 @@ taf:
   nginx:
     name: taf-nginx
     registry: registry.gitlab.com/opengeoweb/backend-services/auth-backend/auth-backend
-    version: "v0.4.2"
+    version: "v0.5.0"
     ENABLE_SSL: "FALSE"
     NGINX_PORT_HTTP: 80
     NGINX_PORT_HTTPS: 443


### PR DESCRIPTION
Geoweb taf-backend version updates.
- aviation-taf-backend default version 1.2.2 -> 2.0.0
- Updated Nginx version 0.4.2 -> 0.5.0
- removed the deprecated `TAF_CONFIG` environment variable