### PR TITLE
Improve linting with OpenShift CRD stubs

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -55,6 +55,12 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.8.0
 
+      - name: Install OpenShift CRD stubs into Kind
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          kubectl apply --filename=openshift-crds/imagestream.yaml
+          kubectl apply --filename=openshift-crds/template.yaml
+
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --target-branch ${{ github.event.repository.default_branch }}

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -60,6 +60,7 @@ jobs:
         run: |
           kubectl apply --filename=openshift-crds/imagestream.yaml
           kubectl apply --filename=openshift-crds/template.yaml
+          # TODO: Add more stubs here if your charts need them
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/fmi-snwc-bc/Chart.yaml
+++ b/charts/fmi-snwc-bc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/fmi-snwc-bc/Chart.yaml
+++ b/charts/fmi-snwc-bc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/openshift-crds/README.md
+++ b/openshift-crds/README.md
@@ -1,0 +1,11 @@
+# OpenShift CRD stubs
+
+These stub CustomResourceDefinitions exist **only** to make Helm-chart linting pass in CI.
+
+They are applied to the Kind test cluster by the GitHub Actions workflow
+[`lint-test.yml`](../.github/workflows/lint-test.yml).
+
+Authoritative (and more complete) CRDs for some resources are available in the
+OpenShift API repository: <https://github.com/openshift/api/>.
+
+Add CRD stubs as needed.

--- a/openshift-crds/imagestream.yaml
+++ b/openshift-crds/imagestream.yaml
@@ -1,0 +1,20 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: imagestreams.image.openshift.io
+spec:
+  group: image.openshift.io
+  scope: Namespaced
+  names:
+    plural: imagestreams
+    singular: imagestream
+    kind: ImageStream
+    shortNames: [is]
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    # Intentionally an empty schema, just to make the Kind based linter happy
+    schema:
+      openAPIV3Schema:
+        type: object

--- a/openshift-crds/template.yaml
+++ b/openshift-crds/template.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: templates.template.openshift.io
+spec:
+  group: template.openshift.io
+  scope: Namespaced
+  names:
+    plural: templates
+    singular: template
+    kind: Template
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    # Intentionally an empty schema, just to make the Kind based linter happy
+    schema:
+      openAPIV3Schema:
+        type: object


### PR DESCRIPTION
Add two OpenShift specific Custom Resource Definitions (actually just stubs) to make 
the Kind based linter happier with OpenShift resources.