### PR TITLE
Update cap-backend

### DIFF
--- a/charts/geoweb-cap-backend/Chart.yaml
+++ b/charts/geoweb-cap-backend/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.4
+version: 1.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.10.5"
+appVersion: "v0.10.9"
 
 maintainers:
   - name: Jusaa

--- a/charts/geoweb-cap-backend/README.md
+++ b/charts/geoweb-cap-backend/README.md
@@ -68,6 +68,7 @@ The following table lists the configurable parameters of the CAP backend chart a
 
 | Chart version | cap version |
 |---------------|-------------|
+| 1.8.0         | 0.10.9      |
 | 1.7.4         | 0.10.5      |
 | 1.7.3         | 0.10.2      |
 | 1.7.2         | 0.10.0      |

--- a/charts/geoweb-cap-backend/values.yaml
+++ b/charts/geoweb-cap-backend/values.yaml
@@ -11,11 +11,11 @@ cap:
   minPodsAvailable: 0
   resources:
     requests:
-      memory: "384Mi"
+      memory: "512Mi"
       cpu: "50m"
     limits:
       memory: "1024Mi"
-      cpu: "1"
+      cpu: "100m"
   startupProbe:
     httpGet:
       path: /healthcheck?startup=true

--- a/charts/geoweb-cap-backend/values.yaml
+++ b/charts/geoweb-cap-backend/values.yaml
@@ -11,11 +11,11 @@ cap:
   minPodsAvailable: 0
   resources:
     requests:
-      memory: "384Mi"
-      cpu: "50m"
+      memory: "768Mi"
+      cpu: "15m"
     limits:
       memory: "1024Mi"
-      cpu: "100m"
+      cpu: "1"
   startupProbe:
     httpGet:
       path: /healthcheck?startup=true

--- a/charts/geoweb-cap-backend/values.yaml
+++ b/charts/geoweb-cap-backend/values.yaml
@@ -15,7 +15,6 @@ cap:
       cpu: "15m"
     limits:
       memory: "1024Mi"
-      cpu: "1"
   startupProbe:
     httpGet:
       path: /healthcheck?startup=true

--- a/charts/geoweb-cap-backend/values.yaml
+++ b/charts/geoweb-cap-backend/values.yaml
@@ -11,7 +11,7 @@ cap:
   minPodsAvailable: 0
   resources:
     requests:
-      memory: "512Mi"
+      memory: "384Mi"
       cpu: "50m"
     limits:
       memory: "1024Mi"


### PR DESCRIPTION
- Updated to latest GeoWeb cap-backend release v0.10.9
- Set new default resource allocations
  - Requests:
    - More memory based on top usage
    - Less CPU to prevent issue with node downscaling
   - Limits:
     - More memory based on top usage
     - Removed CPU limit entirely