### PR TITLE
Update geoweb-frontend

### DIFF
--- a/charts/geoweb-frontend/Chart.yaml
+++ b/charts/geoweb-frontend/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.19.1
+version: 3.20.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v12.4.2"
+appVersion: "v12.6.0"
 
 maintainers:
   - name: Jusaa

--- a/charts/geoweb-frontend/README.md
+++ b/charts/geoweb-frontend/README.md
@@ -230,6 +230,7 @@ The following table lists the configurable parameters of the GeoWeb frontend cha
 
 | Chart version | frontend version |
 |---------------|------------------|
+| 3.20.0        | 12.6.0           |
 | 3.19.1        | 12.4.2           |
 | 3.19.0        | 12.3.0           |
 | 3.18.1        | 12.3.0           |

--- a/charts/geoweb-frontend/values.yaml
+++ b/charts/geoweb-frontend/values.yaml
@@ -16,11 +16,11 @@ frontend:
   secretServiceAccount: geoweb-service-account
   resources:
     requests:
-      memory: "64Mi"
-      cpu: "25m"
-    limits:
       memory: "128Mi"
-      cpu: "50m"
+      cpu: "15m"
+    limits:
+      memory: "256Mi"
+      cpu: "1"
   startupProbe:
     httpGet:
       path: /assets/config.json?startup=true

--- a/charts/geoweb-frontend/values.yaml
+++ b/charts/geoweb-frontend/values.yaml
@@ -16,11 +16,11 @@ frontend:
   secretServiceAccount: geoweb-service-account
   resources:
     requests:
-      memory: "100Mi"
-      cpu: "100m"
+      memory: "64Mi"
+      cpu: "25m"
     limits:
-      memory: "200Mi"
-      cpu: "1"
+      memory: "128Mi"
+      cpu: "50m"
   startupProbe:
     httpGet:
       path: /assets/config.json?startup=true

--- a/charts/geoweb-frontend/values.yaml
+++ b/charts/geoweb-frontend/values.yaml
@@ -20,7 +20,6 @@ frontend:
       cpu: "15m"
     limits:
       memory: "256Mi"
-      cpu: "1"
   startupProbe:
     httpGet:
       path: /assets/config.json?startup=true


### PR DESCRIPTION
Set new default resource allocations
- Requests:
   - More memory based on top usage
   - Less CPU to prevent issue with node downscaling
- Limits:
   - More memory based on top usage
   - Removed CPU limit entirely