### PR TITLE
Update taf-backend

### DIFF
--- a/charts/geoweb-taf-backend/Chart.yaml
+++ b/charts/geoweb-taf-backend/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.0.1"
+appVersion: "v2.0.3"
 
 maintainers:
   - name: Jusaa

--- a/charts/geoweb-taf-backend/README.md
+++ b/charts/geoweb-taf-backend/README.md
@@ -155,6 +155,7 @@ The following table lists the configurable parameters of the Taf backend chart a
 | `taf.nginx.startupProbe` | Configure nginx container startupProbe | see defaults from `values.yaml` |
 | `taf.nginx.livenessProbe` | Configure nginx container livenessProbe | see defaults from `values.yaml` |
 | `taf.nginx.readinessProbe` | Configure nginx container readinessProbe | see defaults from `values.yaml` |
+| `taf.nginx.ENV_VAR_STRICT_MODE` | Enable check if all necessary variables for authentication and authorization are set | `false` |
 | `taf.publisher.name` | Name of publisher container  | `taf-publisher` |
 | `taf.publisher.registry` | Registry to fetch image | `registry.gitlab.com/opengeoweb/backend-services/aviation-taf-backend/aviation-taf-backend-publisher-local` |
 | `taf.publisher.port` | Port used for publisher | `8090`|
@@ -186,6 +187,7 @@ The following table lists the configurable parameters of the Taf backend chart a
 
 | Chart version | taf version |
 |---------------|-------------|
+| 1.2.0         | 2.0.3       |
 | 1.1.2         | 2.0.1       |
 | 1.1.1         | 2.0.0       |
 | 1.0.3         | 1.2.2       |

--- a/charts/geoweb-taf-backend/templates/taf-nginx-configmap.yaml
+++ b/charts/geoweb-taf-backend/templates/taf-nginx-configmap.yaml
@@ -49,3 +49,6 @@ data:
 {{- if .Values.taf.nginx.NGINX_PORT_HTTPS }}
   NGINX_PORT_HTTPS: {{ .Values.taf.nginx.NGINX_PORT_HTTPS | quote }}
 {{- end }}
+{{- if .Values.taf.nginx.ENV_VAR_STRICT_MODE }}
+  ENV_VAR_STRICT_MODE: {{ .Values.taf.nginx.ENV_VAR_STRICT_MODE | quote }}
+{{- end }}

--- a/charts/geoweb-taf-backend/values.yaml
+++ b/charts/geoweb-taf-backend/values.yaml
@@ -20,7 +20,6 @@ taf:
       cpu: "15m"
     limits:
       memory: "1024Mi"
-      cpu: "1"
   startupProbe:
     httpGet:
       path: /healthcheck?startup=true
@@ -58,7 +57,6 @@ taf:
         cpu: "10m"
       limits:
         memory: "1024Mi"
-        cpu: "1"
     startupProbe:
       httpGet:
         path: /healthcheck?startup=true
@@ -91,7 +89,6 @@ taf:
         cpu: "50m"
       limits:
         memory: "128Mi"
-        cpu: "1"
     startupProbe:
       httpGet:
         path: /healthcheck?startup=true
@@ -128,7 +125,6 @@ taf:
         cpu: "5m"
       limits:
         memory: "32Mi"
-        cpu: "1"
     startupProbe:
       httpGet:
         path: /health_check?startup=true
@@ -160,7 +156,6 @@ taf:
         cpu: "25m"
       limits:
         memory: "256Mi"
-        cpu: "1"
     startupProbe:
       exec:
         command:

--- a/charts/geoweb-taf-backend/values.yaml
+++ b/charts/geoweb-taf-backend/values.yaml
@@ -159,7 +159,7 @@ taf:
         memory: "128Mi"
         cpu: "25m"
       limits:
-        memory: "364Mi"
+        memory: "256Mi"
         cpu: "1"
     startupProbe:
       exec:

--- a/charts/geoweb-taf-backend/values.yaml
+++ b/charts/geoweb-taf-backend/values.yaml
@@ -16,8 +16,8 @@ taf:
   secretServiceAccount: taf-service-account
   resources:
     requests:
-      memory: "250Mi"
-      cpu: "50m"
+      memory: "512Mi"
+      cpu: "15m"
     limits:
       memory: "1024Mi"
       cpu: "1"
@@ -54,8 +54,8 @@ taf:
     port: 8081
     resources:
       requests:
-        memory: "250Mi"
-        cpu: "50m"
+        memory: "512Mi"
+        cpu: "10m"
       limits:
         memory: "1024Mi"
         cpu: "1"
@@ -87,10 +87,10 @@ taf:
     PUBLISH_DIR: /app/output
     resources:
       requests:
-        memory: "50Mi"
+        memory: "64Mi"
         cpu: "50m"
       limits:
-        memory: "512Mi"
+        memory: "128Mi"
         cpu: "1"
     startupProbe:
       httpGet:
@@ -116,18 +116,19 @@ taf:
   nginx:
     name: taf-nginx
     registry: registry.gitlab.com/opengeoweb/backend-services/auth-backend/auth-backend
-    version: "v0.4.2"
+    version: "v0.6.0"
     ENABLE_SSL: "FALSE"
     NGINX_PORT_HTTP: 80
     NGINX_PORT_HTTPS: 443
     BACKEND_HOST: localhost:8000
+    ENV_VAR_STRICT_MODE: "FALSE"
     resources:
       requests:
-        memory: "10Mi"
-        cpu: "10m"
+        memory: "16Mi"
+        cpu: "5m"
       limits:
-        memory: "100Mi"
-        cpu: "100m"
+        memory: "32Mi"
+        cpu: "1"
     startupProbe:
       httpGet:
         path: /health_check?startup=true
@@ -155,10 +156,10 @@ taf:
     TAFPLACEHOLDER_KEEPRUNNING: true
     resources:
       requests:
-        memory: "50Mi"
-        cpu: "50m"
+        memory: "128Mi"
+        cpu: "25m"
       limits:
-        memory: "512Mi"
+        memory: "364Mi"
         cpu: "1"
     startupProbe:
       exec:

--- a/charts/geoweb-taf-backend/values.yaml
+++ b/charts/geoweb-taf-backend/values.yaml
@@ -50,7 +50,7 @@ taf:
   messageconverter:
     name: taf-messageconverter
     registry: registry.gitlab.com/opengeoweb/avi-msgconverter/geoweb-knmi-avi-messageservices
-    version: "0.10.1"
+    version: "1.0.0"
     port: 8081
     resources:
       requests:

--- a/charts/geoweb-taf-backend/values.yaml
+++ b/charts/geoweb-taf-backend/values.yaml
@@ -50,7 +50,7 @@ taf:
   messageconverter:
     name: taf-messageconverter
     registry: registry.gitlab.com/opengeoweb/avi-msgconverter/geoweb-knmi-avi-messageservices
-    version: "1.0.0"
+    version: "v1.0.0"
     port: 8081
     resources:
       requests:


### PR DESCRIPTION
- Updated to latest GeoWeb taf-backend release v2.0.3
- Set new default resource allocations
  - Requests: 
    - More memory based on top usage
    - Less CPU to prevent issue with node downscaling
   - Limits:
     - More memory based on top usage
     - Removed CPU limit entirely 
- Updated auth-backend version and added new env var (default "false")
- Updated messageconverter version