### PR TITLE
Update warnings-backend

### DIFF
--- a/charts/geoweb-warnings-backend/Chart.yaml
+++ b/charts/geoweb-warnings-backend/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.4
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.10.2"
+appVersion: "v1.10.4"
 
 maintainers:
   - name: Jusaa

--- a/charts/geoweb-warnings-backend/README.md
+++ b/charts/geoweb-warnings-backend/README.md
@@ -135,6 +135,7 @@ The following table lists the configurable parameters of the Warnings backend ch
 | `warnings.nginx.startupProbe` | Configure nginx container startupProbe | see defaults from `values.yaml` |
 | `warnings.nginx.livenessProbe` | Configure nginx container livenessProbe | see defaults from `values.yaml` |
 | `warnings.nginx.readinessProbe` | Configure nginx container readinessProbe | see defaults from `values.yaml` |
+| `warnings.nginx.ENV_VAR_STRICT_MODE` | Enable check if all necessary variables for authentication and authorization are set | `false` |
 | `warnings.db.enableDefaultDb` | Enable default postgres database | `true` |
 | `warnings.db.name` | Default postgres database container name | `postgres` |
 | `warnings.db.image` | Default postgres database image | `postgres` |
@@ -159,6 +160,7 @@ The following table lists the configurable parameters of the Warnings backend ch
 
 | Chart version | warnings version |
 |---------------|------------------|
+| 1.3.0         | 1.10.4           |
 | 1.2.4         | 1.10.2           |
 | 1.2.3         | 1.10.0           |
 | 1.2.2         | 1.8.1            |

--- a/charts/geoweb-warnings-backend/templates/warnings-nginx-configmap.yaml
+++ b/charts/geoweb-warnings-backend/templates/warnings-nginx-configmap.yaml
@@ -45,3 +45,6 @@ data:
 {{- if .Values.warnings.nginx.NGINX_PORT_HTTPS }}
   NGINX_PORT_HTTPS: {{ .Values.warnings.nginx.NGINX_PORT_HTTPS | quote }}
 {{- end }}
+{{- if .Values.warnings.nginx.ENV_VAR_STRICT_MODE }}
+  ENV_VAR_STRICT_MODE: {{ .Values.warnings.nginx.ENV_VAR_STRICT_MODE | quote }}
+{{- end }}

--- a/charts/geoweb-warnings-backend/values.yaml
+++ b/charts/geoweb-warnings-backend/values.yaml
@@ -19,7 +19,6 @@ warnings:
       cpu: "15m"
     limits:
       memory: "1024Mi"
-      cpu: "1"
   startupProbe:
     httpGet:
       path: /healthcheck?startup=true
@@ -59,7 +58,6 @@ warnings:
         cpu: "5m"
       limits:
         memory: "32Mi"
-        cpu: "1"
     startupProbe:
       httpGet:
         path: /health_check?startup=true

--- a/charts/geoweb-warnings-backend/values.yaml
+++ b/charts/geoweb-warnings-backend/values.yaml
@@ -15,8 +15,8 @@ warnings:
   secretServiceAccount: warnings-service-account
   resources:
     requests:
-      memory: "250Mi"
-      cpu: "50m"
+      memory: "512Mi"
+      cpu: "15m"
     limits:
       memory: "1024Mi"
       cpu: "1"
@@ -47,18 +47,19 @@ warnings:
   nginx:
     name: warnings-nginx
     registry: registry.gitlab.com/opengeoweb/backend-services/auth-backend/auth-backend
-    version: "v0.4.2"
+    version: "v0.6.0"
     ENABLE_SSL: "FALSE"
     BACKEND_HOST: 0.0.0.0:8080
     NGINX_PORT_HTTP: 80
     NGINX_PORT_HTTPS: 443
+    ENV_VAR_STRICT_MODE: "FALSE"
     resources:
       requests:
-        memory: "10Mi"
-        cpu: "10m"
+        memory: "16Mi"
+        cpu: "5m"
       limits:
-        memory: "100Mi"
-        cpu: "100m"
+        memory: "32Mi"
+        cpu: "1"
     startupProbe:
       httpGet:
         path: /health_check?startup=true


### PR DESCRIPTION
- Updated to latest GeoWeb warnings-backend release v1.10.4
- Set new default resource allocations
  - Requests:
    - More memory based on top usage
    - Less CPU to prevent issue with node downscaling
   - Limits:
     - More memory based on top usage
     - Removed CPU limit entirely
 - Added new auth-backend env var (default "false") 