### PR TITLE
Fix ingress service name reference in smartmetserver chart

### DIFF
--- a/charts/smartmetserver/Chart.yaml
+++ b/charts/smartmetserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: smartmetserver
 description: A Helm chart to deploy SmartMet Server for Kubernetes
 type: application
-version: 1.5.0
+version: 1.5.1
 appVersion: "25.08.25"
 home: https://github.com/fmidev/helm-charts
 sources:

--- a/charts/smartmetserver/templates/ingress.yaml
+++ b/charts/smartmetserver/templates/ingress.yaml
@@ -41,7 +41,7 @@ spec:
             pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ $.Values.smartmetserver.name }}
+                name: {{ include "smartmetserver.fullname" $ }}
                 port:
                   number: {{ $.Values.smartmetserver.svcPort }}
           {{- end }}


### PR DESCRIPTION
## Problem
The ingress template was using a static service name reference (`smartmetserver.name`) which caused 503 Service Temporarily Unavailable errors when the ingress tried to route to a non-existent service.

## Root Cause
- The ingress template used `{{ $.Values.smartmetserver.name }}` which resolves to the static value "smartmetserver"
- However, the actual service name is generated using `{{ include "smartmetserver.fullname" . }}` which includes the Helm release name
- This mismatch caused the ingress to look for a service named "smartmetserver" instead of the actual service name like "smartmetservertest"

## Solution
Changed the ingress template to use the same naming pattern as the service:
- **Before**: `name: {{ $.Values.smartmetserver.name }}`
- **After**: `name: {{ include "smartmetserver.fullname" $ }}`

## Testing
- Verified that port-forward to service works correctly
- Confirmed that the service endpoints are healthy
- The 503 error was specifically caused by the service name mismatch

## Impact
- Fixes ingress routing for all smartmetserver deployments
- No breaking changes - uses the same naming convention as other templates