### PR TITLE
feat(smartmet-verify): optional CNPG database, /tmp emptyDir, flexible probes

### DIFF
--- a/charts/smartmet-verify/Chart.yaml
+++ b/charts/smartmet-verify/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: smartmet-verify
 description: Helm chart for deploying SmartMet Verify applications (GUI and runner)
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.1.0"
 home: https://github.com/fmidev/helm-charts
 sources:

--- a/charts/smartmet-verify/README.md
+++ b/charts/smartmet-verify/README.md
@@ -264,6 +264,67 @@ runner:
     port: 8080   # default
 ```
 
+## Writable `/tmp` volume
+
+Both components run with `securityContext.readOnlyRootFilesystem: true`, which
+blocks Tomcat/JVM writes to `/tmp`. To keep the root filesystem read-only while
+still allowing these writes, the chart mounts an `emptyDir` at `/tmp` by
+default. It is controlled independently per component:
+
+```yaml
+gui:
+  tmpDir:
+    enabled: true   # default
+runner:
+  tmpDir:
+    enabled: true   # default
+```
+
+Disable only if you provide an alternative writable location for `/tmp`.
+
+## Probes
+
+The GUI and runner liveness and readiness probes support the full Kubernetes
+probe-action set. Each of `gui.probes.liveness`, `gui.probes.readiness`,
+`runner.probes.liveness` and `runner.probes.readiness` accepts one of the
+optional keys `httpGet`, `tcpSocket` or `exec` (passed through verbatim to the
+pod spec). If none is set, the template falls back to the existing `path:`
+shortcut, which performs an `httpGet` against the named `http` port.
+
+The runner does not expose an HTTP server by default, so `exec` probes are the
+recommended choice there:
+
+```yaml
+runner:
+  probes:
+    liveness:
+      exec:
+        command: ["true"]
+      initialDelaySeconds: 30
+      periodSeconds: 30
+    readiness:
+      exec:
+        command: ["true"]
+      initialDelaySeconds: 10
+      periodSeconds: 15
+```
+
+The GUI's Spring Security configuration protects `/actuator/**` by default, so
+the `path:` shortcut returns HTTP 401 unless the `noauth` Spring profile is
+active or the health endpoints are explicitly permitted. A `tcpSocket` probe
+avoids this:
+
+```yaml
+gui:
+  probes:
+    liveness:
+      tcpSocket:
+        port: http
+    readiness:
+      tcpSocket:
+        port: http
+```
+
 ## Installation
 
 1. Add Helm repo:
@@ -275,6 +336,126 @@ helm repo update
 ```shell
 helm install smartmet-verify fmidev/smartmet-verify -f values.yaml
 ```
+
+## Database (optional)
+
+The chart can optionally provision a PostgreSQL/PostGIS database using
+[CloudNativePG](https://cloudnative-pg.io/) (CNPG). This is a convenience for
+clusters that do not already have an external database; any existing
+PostgreSQL/PostGIS instance continues to work unchanged.
+
+### Install the CloudNativePG operator
+
+**The CloudNativePG operator is NOT installed by this chart.** You must install
+it separately, cluster-wide, before enabling the database:
+
+```shell
+kubectl apply --server-side -f \
+  https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.29.0/cnpg-1.29.0.yaml
+```
+
+The above is the version this chart has been tested against. Any reasonably
+current CNPG release should work.
+
+### Enable the database
+
+```yaml
+database:
+  enabled: true
+  name: verification-db   # default
+```
+
+When enabled, the chart creates a `postgresql.cnpg.io/v1` `Cluster` named by
+`database.name` (default `verification-db`). The default image is
+`ghcr.io/cloudnative-pg/postgis:16-3.4`.
+
+`database.spec` is a pass-through to the CNPG `Cluster.spec` — anything CNPG
+supports goes there.
+
+### Init SQL
+
+The chart does not vendor the SmartMet Verify schema. You must provide the init
+SQL yourself as an existing ConfigMap and reference it from `database.spec`.
+
+Create the ConfigMap:
+
+```shell
+kubectl -n <ns> create configmap verification-db-init-sql \
+  --from-file=0000-pre-init.sql \
+  --from-file=0001-production-schema.sql \
+  --from-file=0002-post-ownership.sql
+```
+
+Reference it via CNPG's `postInitSQLRefs` and `postInitApplicationSQLRefs`:
+
+```yaml
+database:
+  spec:
+    bootstrap:
+      initdb:
+        postInitSQLRefs:
+          configMapRefs:
+            - { name: verification-db-init-sql, key: 0000-pre-init.sql }
+        postInitApplicationSQLRefs:
+          configMapRefs:
+            - { name: verification-db-init-sql, key: 0002-post-ownership.sql }
+            - { name: verification-db-init-sql, key: 0001-production-schema.sql }
+```
+
+`0002-post-ownership.sql` is a small user-supplied wrapper that transfers the
+application database's ownership to `verifadmin` before the schema loads. It is
+needed because the CNPG initdb `owner: app` default avoids conflicting with the
+`CREATE ROLE verifadmin` in `0000-pre-init.sql`, so ownership has to be handed
+over explicitly. Example contents:
+
+```sql
+ALTER DATABASE verifapi OWNER TO verifadmin;
+ALTER SCHEMA public OWNER TO verifadmin;
+GRANT USAGE ON SCHEMA public TO verif_ro;
+GRANT CREATE ON SCHEMA public TO verifadmin;
+```
+
+### Role passwords
+
+Role passwords come from `kubernetes.io/basic-auth` secrets that you create,
+one per managed role:
+
+```shell
+kubectl -n <ns> create secret generic verification-db-verifwww \
+  --type=kubernetes.io/basic-auth \
+  --from-literal=username=verifwww \
+  --from-literal=password=<strong>
+```
+
+The same password must also end up in the application config Secret (e.g.
+`smartmet-verify-gui-config`) that the GUI and runner mount. Keep the two in
+sync whenever you rotate a password.
+
+### Managed role memberships
+
+**Pitfall:** CNPG's `managed.roles` reconciliation removes any role memberships
+it did not declare itself. If a role's privileges come from a
+`GRANT <group_role> TO <user>` line in `0000-pre-init.sql`, you must **also**
+repeat that via the `inRoles:` field on the managed role — otherwise CNPG will
+revoke it on the next reconcile.
+
+`examples/values-rke2.yaml` shows `verifwww` with `inRoles: [verif_ro]` and
+`verifrun` with `inRoles: [verif_data_rw]` for exactly this reason.
+
+### Service hostname
+
+CNPG creates `<name>-rw`, `<name>-ro` and `<name>-r` services for the cluster.
+Applications that hard-code `verification-db` as the database hostname (e.g.
+in a pre-existing `application.yaml`) can get that name via
+`database.spec.managed.services.additional` — a `selectorType: rw` service
+template named `verification-db`. See `examples/values-rke2.yaml` for the exact
+shape.
+
+### Full example
+
+See [`examples/values-rke2.yaml`](./examples/values-rke2.yaml) for a complete
+working database configuration, including managed roles, additional services
+and init SQL wiring.
 
 ## Notes for operators
 

--- a/charts/smartmet-verify/examples/values-rke2.yaml
+++ b/charts/smartmet-verify/examples/values-rke2.yaml
@@ -13,6 +13,18 @@ gui:
       enabled: true
       size: 5Gi
 
+  # The GUI listens on HTTP port 8080 when its application.yaml sets
+  # `security.require-ssl: false` (recommended for cluster-internal traffic).
+  # With Spring Security protecting /actuator/**, fall back to tcpSocket probes
+  # unless the "noauth" profile is active or the health endpoints are permitted.
+  probes:
+    liveness:
+      tcpSocket:
+        port: http
+    readiness:
+      tcpSocket:
+        port: http
+
   ingress:
     enabled: true
     className: nginx
@@ -36,3 +48,89 @@ runner:
     logs:
       enabled: true
       storageClassName: local-path
+
+  # The runner has no HTTP server. Exec probes keep Kubernetes happy without
+  # turning on an Actuator endpoint.
+  probes:
+    liveness:
+      exec:
+        command: ["true"]
+    readiness:
+      exec:
+        command: ["true"]
+
+# Optional PostgreSQL/PostGIS database managed by CloudNativePG.
+#
+# Prerequisites:
+#   1. Install the CloudNativePG operator (see chart README).
+#   2. Create a ConfigMap that holds your init SQL scripts, e.g.:
+#        kubectl -n <ns> create configmap verification-db-init-sql \
+#          --from-file=0000-pre-init.sql \
+#          --from-file=0001-production-schema.sql \
+#          --from-file=0002-post-ownership.sql
+#   3. Create basic-auth secrets for each managed role, e.g.:
+#        kubectl -n <ns> create secret generic verification-db-verifwww \
+#          --type=kubernetes.io/basic-auth \
+#          --from-literal=username=verifwww --from-literal=password=<strong>
+database:
+  enabled: true
+  name: verification-db
+  spec:
+    instances: 1
+    imageName: ghcr.io/cloudnative-pg/postgis:16-3.4
+    env:
+      - name: TZ
+        value: UTC
+    postgresql:
+      parameters:
+        timezone: UTC
+        log_timezone: UTC
+    storage:
+      size: 20Gi
+      storageClass: local-path
+    bootstrap:
+      initdb:
+        database: verifapi
+        owner: app
+        postInitSQLRefs:
+          configMapRefs:
+            - name: verification-db-init-sql
+              key: 0000-pre-init.sql
+        postInitApplicationSQLRefs:
+          configMapRefs:
+            - name: verification-db-init-sql
+              key: 0002-post-ownership.sql
+            - name: verification-db-init-sql
+              key: 0001-production-schema.sql
+    managed:
+      roles:
+        - name: verifadmin
+          ensure: present
+          login: true
+          inherit: true
+          passwordSecret:
+            name: verification-db-verifadmin
+        - name: verifwww
+          ensure: present
+          login: true
+          inherit: true
+          inRoles:
+            - verif_ro
+          passwordSecret:
+            name: verification-db-verifwww
+        - name: verifrun
+          ensure: present
+          login: true
+          inherit: true
+          inRoles:
+            - verif_data_rw
+          passwordSecret:
+            name: verification-db-verifrun
+      services:
+        additional:
+          # Exposes the primary as `verification-db` so application configs
+          # that expect that hostname work without change.
+          - selectorType: rw
+            serviceTemplate:
+              metadata:
+                name: verification-db

--- a/charts/smartmet-verify/templates/_helpers.tpl
+++ b/charts/smartmet-verify/templates/_helpers.tpl
@@ -65,6 +65,51 @@ app.kubernetes.io/component: {{ $component }}
 app.kubernetes.io/component: {{ $component }}
 {{- end -}}
 
+{{/*
+Render a Kubernetes probe from a probe spec.
+
+Input: a map like `.Values.<component>.probes.liveness`.
+The probe action is picked in this priority order:
+
+  1. exec       — map with a command list
+  2. tcpSocket  — map with a port
+  3. httpGet    — map with path/port/scheme/httpHeaders
+  4. path       — legacy shortcut, expanded to httpGet on the named "http" port
+
+Timing fields are forwarded when set.
+*/}}
+{{- define "smartmet-verify.probe" -}}
+{{- if .exec -}}
+exec:
+  {{- toYaml .exec | nindent 2 }}
+{{- else if .tcpSocket -}}
+tcpSocket:
+  {{- toYaml .tcpSocket | nindent 2 }}
+{{- else if .httpGet -}}
+httpGet:
+  {{- toYaml .httpGet | nindent 2 }}
+{{- else if .path -}}
+httpGet:
+  path: {{ .path }}
+  port: http
+{{- end }}
+{{- with .initialDelaySeconds }}
+initialDelaySeconds: {{ . }}
+{{- end }}
+{{- with .periodSeconds }}
+periodSeconds: {{ . }}
+{{- end }}
+{{- with .timeoutSeconds }}
+timeoutSeconds: {{ . }}
+{{- end }}
+{{- with .failureThreshold }}
+failureThreshold: {{ . }}
+{{- end }}
+{{- with .successThreshold }}
+successThreshold: {{ . }}
+{{- end }}
+{{- end -}}
+
 {{- define "smartmet-verify.image" -}}
 {{- $root := index . 0 -}}
 {{- $image := index . 1 -}}

--- a/charts/smartmet-verify/templates/database-cluster.yaml
+++ b/charts/smartmet-verify/templates/database-cluster.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.database.enabled }}
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ .Values.database.name }}
+  labels:
+    {{- include "smartmet-verify.componentLabels" (list . "database") | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- toYaml .Values.database.spec | nindent 2 }}
+{{- end }}

--- a/charts/smartmet-verify/templates/gui-deployment.yaml
+++ b/charts/smartmet-verify/templates/gui-deployment.yaml
@@ -66,34 +66,26 @@ spec:
           {{- end }}
           {{- if .Values.gui.probes.liveness.enabled }}
           livenessProbe:
-            httpGet:
-              path: {{ .Values.gui.probes.liveness.path }}
-              port: http
-            initialDelaySeconds: {{ .Values.gui.probes.liveness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.gui.probes.liveness.periodSeconds }}
-            timeoutSeconds: {{ .Values.gui.probes.liveness.timeoutSeconds }}
-            failureThreshold: {{ .Values.gui.probes.liveness.failureThreshold }}
+            {{- include "smartmet-verify.probe" .Values.gui.probes.liveness | nindent 12 }}
           {{- end }}
           {{- if .Values.gui.probes.readiness.enabled }}
           readinessProbe:
-            httpGet:
-              path: {{ .Values.gui.probes.readiness.path }}
-              port: http
-            initialDelaySeconds: {{ .Values.gui.probes.readiness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.gui.probes.readiness.periodSeconds }}
-            timeoutSeconds: {{ .Values.gui.probes.readiness.timeoutSeconds }}
-            failureThreshold: {{ .Values.gui.probes.readiness.failureThreshold }}
+            {{- include "smartmet-verify.probe" .Values.gui.probes.readiness | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.gui.resources | nindent 12 }}
           {{- $hasConfigMount := and (eq .Values.gui.config.mode "secretFile") .Values.gui.config.secretFile.secretName }}
-          {{- if or $hasConfigMount .Values.gui.persistence.logs.enabled .Values.global.extraVolumeMounts .Values.gui.extraVolumeMounts }}
+          {{- if or $hasConfigMount .Values.gui.tmpDir.enabled .Values.gui.persistence.logs.enabled .Values.global.extraVolumeMounts .Values.gui.extraVolumeMounts }}
           volumeMounts:
             {{- if $hasConfigMount }}
             - name: gui-config
               mountPath: {{ printf "%s/%s" .Values.gui.config.secretFile.mountPath .Values.gui.config.secretFile.fileName }}
               subPath: {{ .Values.gui.config.secretFile.secretKey }}
               readOnly: true
+            {{- end }}
+            {{- if .Values.gui.tmpDir.enabled }}
+            - name: tmp
+              mountPath: /tmp
             {{- end }}
             {{- if .Values.gui.persistence.logs.enabled }}
             - name: gui-logs
@@ -106,12 +98,16 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if or $hasConfigMount .Values.gui.persistence.logs.enabled .Values.global.extraVolumes .Values.gui.extraVolumes }}
+      {{- if or $hasConfigMount .Values.gui.tmpDir.enabled .Values.gui.persistence.logs.enabled .Values.global.extraVolumes .Values.gui.extraVolumes }}
       volumes:
         {{- if $hasConfigMount }}
         - name: gui-config
           secret:
             secretName: {{ .Values.gui.config.secretFile.secretName }}
+        {{- end }}
+        {{- if .Values.gui.tmpDir.enabled }}
+        - name: tmp
+          emptyDir: {}
         {{- end }}
         {{- if .Values.gui.persistence.logs.enabled }}
         - name: gui-logs

--- a/charts/smartmet-verify/templates/runner-deployment.yaml
+++ b/charts/smartmet-verify/templates/runner-deployment.yaml
@@ -66,34 +66,26 @@ spec:
           {{- end }}
           {{- if .Values.runner.probes.liveness.enabled }}
           livenessProbe:
-            httpGet:
-              path: {{ .Values.runner.probes.liveness.path }}
-              port: http
-            initialDelaySeconds: {{ .Values.runner.probes.liveness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.runner.probes.liveness.periodSeconds }}
-            timeoutSeconds: {{ .Values.runner.probes.liveness.timeoutSeconds }}
-            failureThreshold: {{ .Values.runner.probes.liveness.failureThreshold }}
+            {{- include "smartmet-verify.probe" .Values.runner.probes.liveness | nindent 12 }}
           {{- end }}
           {{- if .Values.runner.probes.readiness.enabled }}
           readinessProbe:
-            httpGet:
-              path: {{ .Values.runner.probes.readiness.path }}
-              port: http
-            initialDelaySeconds: {{ .Values.runner.probes.readiness.initialDelaySeconds }}
-            periodSeconds: {{ .Values.runner.probes.readiness.periodSeconds }}
-            timeoutSeconds: {{ .Values.runner.probes.readiness.timeoutSeconds }}
-            failureThreshold: {{ .Values.runner.probes.readiness.failureThreshold }}
+            {{- include "smartmet-verify.probe" .Values.runner.probes.readiness | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.runner.resources | nindent 12 }}
           {{- $hasConfigMount := and (eq .Values.runner.config.mode "secretFile") .Values.runner.config.secretFile.secretName }}
-          {{- if or $hasConfigMount .Values.runner.persistence.logs.enabled .Values.global.extraVolumeMounts .Values.runner.extraVolumeMounts }}
+          {{- if or $hasConfigMount .Values.runner.tmpDir.enabled .Values.runner.persistence.logs.enabled .Values.global.extraVolumeMounts .Values.runner.extraVolumeMounts }}
           volumeMounts:
             {{- if $hasConfigMount }}
             - name: runner-config
               mountPath: {{ printf "%s/%s" .Values.runner.config.secretFile.mountPath .Values.runner.config.secretFile.fileName }}
               subPath: {{ .Values.runner.config.secretFile.secretKey }}
               readOnly: true
+            {{- end }}
+            {{- if .Values.runner.tmpDir.enabled }}
+            - name: tmp
+              mountPath: /tmp
             {{- end }}
             {{- if .Values.runner.persistence.logs.enabled }}
             - name: runner-logs
@@ -106,12 +98,16 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if or $hasConfigMount .Values.runner.persistence.logs.enabled .Values.global.extraVolumes .Values.runner.extraVolumes }}
+      {{- if or $hasConfigMount .Values.runner.tmpDir.enabled .Values.runner.persistence.logs.enabled .Values.global.extraVolumes .Values.runner.extraVolumes }}
       volumes:
         {{- if $hasConfigMount }}
         - name: runner-config
           secret:
             secretName: {{ .Values.runner.config.secretFile.secretName }}
+        {{- end }}
+        {{- if .Values.runner.tmpDir.enabled }}
+        - name: tmp
+          emptyDir: {}
         {{- end }}
         {{- if .Values.runner.persistence.logs.enabled }}
         - name: runner-logs

--- a/charts/smartmet-verify/values.yaml
+++ b/charts/smartmet-verify/values.yaml
@@ -99,6 +99,14 @@ gui:
       storageClassName: ""
       mountPath: /var/log/tomcat
 
+  # Writable /tmp mounted as emptyDir. Required when readOnlyRootFilesystem is
+  # true (the default) because Tomcat and the JVM need to write to /tmp.
+  tmpDir:
+    enabled: true
+
+  # Probe action. By default this is an httpGet against `path` on the named
+  # `http` port. Set one of `httpGet`, `tcpSocket` or `exec` to use a different
+  # action — those override the `path` shortcut when present.
   probes:
     liveness:
       enabled: true
@@ -198,6 +206,11 @@ runner:
       storageClassName: ""
       mountPath: /var/log/tomcat
 
+  tmpDir:
+    enabled: true
+
+  # The runner has no HTTP server by default, so probe overrides are common.
+  # See the `exec` / `tcpSocket` / `httpGet` examples in values-rke2.yaml.
   probes:
     liveness:
       enabled: true
@@ -213,3 +226,77 @@ runner:
       periodSeconds: 20
       timeoutSeconds: 3
       failureThreshold: 6
+
+# Optional PostgreSQL/PostGIS database managed by the CloudNativePG operator.
+#
+# The operator itself is NOT installed by this chart. Before setting
+# `database.enabled: true` you must install CloudNativePG (see README).
+#
+# The fields under `spec` are passed through to the `Cluster` resource verbatim,
+# so anything the CNPG API supports can be configured from here.
+database:
+  enabled: false
+
+  # Cluster name. Also becomes the stem of the CNPG-generated services
+  # (`<name>-rw`, `<name>-ro`, `<name>-r`). Applications that use a different
+  # hostname (e.g. `verification-db`) can add an alias via
+  # `database.spec.managed.services.additional`.
+  name: verification-db
+
+  spec:
+    instances: 1
+    imageName: ghcr.io/cloudnative-pg/postgis:16-3.4
+
+    env:
+      - name: TZ
+        value: UTC
+
+    postgresql:
+      parameters:
+        timezone: UTC
+        log_timezone: UTC
+
+    storage:
+      size: 20Gi
+      # storageClass: ""
+
+    # By keeping `owner: app` the operator creates a throw-away `app` role,
+    # which lets pre-init SQL CREATE ROLE verifadmin without colliding.
+    # A post-init SQL should transfer ownership of the application database
+    # to verifadmin before the production schema runs.
+    bootstrap:
+      initdb:
+        database: verifapi
+        owner: app
+        # References to ConfigMap/Secret keys containing SQL scripts.
+        # Supply these as existing ConfigMaps — the chart does not vendor
+        # the SmartMet Verify schema.
+        postInitSQLRefs:
+          configMapRefs: []
+          # - name: verification-db-init-sql
+          #   key: 0000-pre-init.sql
+        postInitApplicationSQLRefs:
+          configMapRefs: []
+          # - name: verification-db-init-sql
+          #   key: 0002-post-ownership.sql
+          # - name: verification-db-init-sql
+          #   key: 0001-production-schema.sql
+
+    # managed.roles and managed.services below give applications access to the
+    # DB under their expected role names and service hostnames.
+    managed:
+      roles: []
+      # - name: verifwww
+      #   ensure: present
+      #   login: true
+      #   inherit: true
+      #   inRoles:
+      #     - verif_ro
+      #   passwordSecret:
+      #     name: verification-db-verifwww
+      services:
+        additional: []
+        # - selectorType: rw
+        #   serviceTemplate:
+        #     metadata:
+        #       name: verification-db


### PR DESCRIPTION
## Summary

Three changes to the `smartmet-verify` chart, discovered while bringing up a fresh deployment on RKE2 + NFS:

- **Optional PostgreSQL/PostGIS database via CloudNativePG.** Gated on `database.enabled` (default `false`). The operator itself is NOT installed by this chart — users install CNPG separately. `database.spec` is a pass-through to the CNPG `Cluster.spec`, so anything CNPG supports works. Init SQL and role-password secrets are user-supplied; the chart does not vendor the SmartMet Verify schema.
- **Writable `/tmp` via emptyDir** (`gui.tmpDir.enabled` / `runner.tmpDir.enabled`, default `true`). Required because `securityContext.readOnlyRootFilesystem: true` otherwise blocks Tomcat/JVM writes to `/tmp`. The previous chart would crash Tomcat on startup (`java.nio.file.FileSystemException: /tmp/tomcat.8443.*: Read-only file system`).
- **Flexible probes.** `probes.liveness` / `.readiness` now accept `httpGet`, `tcpSocket` or `exec`. The legacy `path:` shortcut still works and is the default. This unblocks the runner (no HTTP server — needs `exec` or no probe at all) and the GUI with Spring Security on `/actuator/**` (TCP probe avoids HTTP 401).

`examples/values-rke2.yaml` now shows all three features wired up end-to-end.

Chart bumped to 0.2.0.

## What's NOT in this PR

- The CloudNativePG operator install. Users run it themselves:
  ```
  kubectl apply --server-side -f https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.29.0/cnpg-1.29.0.yaml
  ```
- The SmartMet Verify init SQL files (they live in `fmidev/fmi-verification-common-sql`). Users `kubectl create configmap ...` themselves, and the chart references the ConfigMap via `database.spec.bootstrap.initdb.postInitSQLRefs` / `postInitApplicationSQLRefs`.

## Test plan

- [x] `helm lint charts/smartmet-verify` passes
- [x] `helm template` with defaults + `gui.enabled=true` + `runner.enabled=true` — Cluster absent, probes render as httpGet on port `http`, `/tmp` emptyDir mounted on both pods
- [x] `helm template` with `examples/values-rke2.yaml` — Cluster rendered, GUI has tcpSocket probes, runner has exec probes
- [x] Legacy configuration (`probes.liveness.path: /foo`, no httpGet/tcpSocket/exec) still renders as httpGet
- [x] End-to-end validated on RKE2: CNPG operator + chart values-rke2.yaml successfully bootstraps database, loads 191-table schema with PostGIS, GUI and runner connect cleanly over HikariCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)