### PR TITLE
feat(smartmetserver): optional NFS mount for /smartmet/share/wms

### DIFF
--- a/charts/smartmetserver/Chart.yaml
+++ b/charts/smartmetserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: smartmetserver
 description: A Helm chart to deploy SmartMet Server for Kubernetes
 type: application
-version: 1.9.6
+version: 1.9.7
 appVersion: "26.01.14"
 home: https://github.com/fmidev/helm-charts
 sources:

--- a/charts/smartmetserver/README.md
+++ b/charts/smartmetserver/README.md
@@ -157,6 +157,28 @@ volume:
       storage: 10Gi
 ```
 
+### Optional WMS NFS Mount
+
+Independent of the main `/smartmet/data` volume, an additional NFS share can be mounted at `/smartmet/share/wms`.
+
+**Helm Command:**
+```bash
+helm upgrade --install smartmetserver fmi/smartmetserver \
+  --namespace smartmetserver --create-namespace \
+  --set wmsVolume.enabled=true \
+  --set wmsVolume.nfs.server=10.12.12.66 \
+  --set wmsVolume.nfs.path=/smartmet/share/wms
+```
+
+**Values YAML:**
+```yaml
+wmsVolume:
+  enabled: true
+  nfs:
+    server: 10.12.12.66
+    path: /smartmet/share/wms
+```
+
 ## Ingress Configuration
 
 ### 1. Basic HTTP Ingress
@@ -362,6 +384,10 @@ The following table lists the configurable parameters of the Smartmetserver char
 | `volume.cephfs.pvc.name` | Name of CephFS PersistentVolumeClaim | `smartmet-data-pvc` |
 | `volume.cephfs.pvc.capacity` | Storage capacity for CephFS PVC | `1Ti` |
 | `volume.cephfs.pvc.storageClassName` | Storage class for dynamic provisioning | `csi-cephfs` |
+| `wmsVolume.enabled` | Mount an additional NFS volume at `/smartmet/share/wms` | `false` |
+| `wmsVolume.readOnly` | Mount the wms NFS volume as read-only | `true` |
+| `wmsVolume.nfs.server` | NFS server address for the wms volume | `""` |
+| `wmsVolume.nfs.path` | NFS export path for the wms volume | `/smartmet/share/wms` |
 | `hpa.minReplicas` | Minimum amount of replicas for horizontal pod autoscaler | `2` |
 | `hpa.maxReplicas` | Maximum amount of replicas for horizontal pod autoscaler | `6` |
 | `hpa.targetCPUUtilizationPercentage` | Target CPU percentage for horizontal pod autoscaler | `60` |

--- a/charts/smartmetserver/templates/deployment.yaml
+++ b/charts/smartmetserver/templates/deployment.yaml
@@ -46,6 +46,11 @@ spec:
         - mountPath: "/etc/smartmet/engines/querydata.conf"
           subPath: "querydata.conf"
           name: smartmet-querydata-config
+        {{- if .Values.wmsVolume.enabled }}
+        - mountPath: "/smartmet/share/wms"
+          name: smartmet-wms-volume
+          readOnly: {{ .Values.wmsVolume.readOnly }}
+        {{- end }}
         livenessProbe:
           tcpSocket:
             port: {{ .Values.smartmetserver.containerPort }}
@@ -97,3 +102,10 @@ spec:
         emptyDir: {}
       - name: archivecache-volume
         emptyDir: {}
+      {{- if .Values.wmsVolume.enabled }}
+      - name: smartmet-wms-volume
+        nfs:
+          server: {{ .Values.wmsVolume.nfs.server }}
+          path: {{ .Values.wmsVolume.nfs.path }}
+          readOnly: {{ .Values.wmsVolume.readOnly }}
+      {{- end }}

--- a/charts/smartmetserver/values.yaml
+++ b/charts/smartmetserver/values.yaml
@@ -156,6 +156,14 @@ volume:
       # For dynamic provisioning, specify storageClassName
       storageClassName: csi-cephfs
 
+# Optional NFS mount for /smartmet/share/wms
+wmsVolume:
+  enabled: false
+  readOnly: true
+  nfs:
+    server: ""
+    path: /smartmet/share/wms
+
 hpa:
   minReplicas: 2
   maxReplicas: 6


### PR DESCRIPTION
## Summary
- Adds an optional NFS volume mount at `/smartmet/share/wms`, mirroring the existing NFS pattern for `/smartmet/data`.
- Disabled by default — opt in via `wmsVolume.enabled=true`.
- Bumps `smartmetserver` chart version `1.9.6` → `1.9.7`.

## Test plan
- [x] `helm lint charts/smartmetserver/` passes
- [x] `helm template` renders cleanly with `wmsVolume.enabled=false` (no wms mount)
- [x] `helm template` renders cleanly with `wmsVolume.enabled=true` (mount + volume produced)
- [ ] CI `ct lint` / `ct install` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)