### PR TITLE
feat(smartmet-verify): chart 0.3.0

### DIFF
--- a/charts/smartmet-verify/Chart.yaml
+++ b/charts/smartmet-verify/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: smartmet-verify
 description: Helm chart for deploying SmartMet Verify applications (GUI and runner)
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "0.1.0"
 home: https://github.com/fmidev/helm-charts
 sources:

--- a/charts/smartmet-verify/README.md
+++ b/charts/smartmet-verify/README.md
@@ -61,7 +61,7 @@ or:
 1. Download the Kubernetes pull secret for the account (e.g. to `pull-secret.yaml`).
 2. Submit the secret to the cluster:
 ```shell
-kubectl create -f pull-secret.yaml --namespace=PUT_NAMESPACE_HERE
+kubectl create -f pull-secret.yaml --namespace=smartmet-verify
 ```
 3. Update Kubernetes configuration:
 ```yaml
@@ -462,20 +462,20 @@ and init SQL wiring.
 - Always use Secrets for database credentials
 - Keep GUI and runner configs separate
 - Use different database users for each app
-- Prefer separate namespaces for production deployments
+- Deploy into a dedicated namespace — the conventional default is `smartmet-verify` (may vary, especially on OpenShift where project names are customer-specific)
 
 ## Troubleshooting
 
 Check pods:
 
 ```shell
-kubectl get pods
+kubectl get pods -n smartmet-verify
 ```
 
 View logs:
 
 ```shell
-kubectl logs <pod-name>
+kubectl logs -n smartmet-verify <pod-name>
 ```
 
 Check mounted configuration:

--- a/charts/smartmet-verify/README.md
+++ b/charts/smartmet-verify/README.md
@@ -52,7 +52,7 @@ The application images are private and hosted in Quay.io
 You must create an image pull secret:
 
 ```shell
-kubectl create secret docker-registry container-registry-pull-secret \
+kubectl create secret docker-registry pull-secret \
   --docker-server=quay.io \
   --docker-username=<USERNAME> \
   --docker-password=<PASSWORD> \
@@ -67,11 +67,10 @@ or:
 ```shell
 kubectl create -f pull-secret.yaml --namespace=smartmet-verify
 ```
-3. Update Kubernetes configuration to reference the secret by the name used above
-   (adjust if you chose a different name, e.g. `quay-pull-secret`):
+3. Update Kubernetes configuration to reference the secret by the name used above:
 ```yaml
 imagePullSecrets:
-  - name: container-registry-pull-secret
+  - name: pull-secret
 ```
 
 ### Image registry and tag overrides
@@ -240,6 +239,10 @@ gui:
       - secretName: verify-tls
         hosts:
           - verify.example.org
+    # Use customAnnotations for cert-manager or other ingress controller annotations.
+    # These are merged with any chart-default annotations.
+    customAnnotations:
+      cert-manager.io/cluster-issuer: letsencrypt
 ```
 
 ### OpenShift (Route)
@@ -257,16 +260,22 @@ gui:
 
 Do not enable both `ingress` and `route` at the same time.
 
-## Runner monitoring port
+## Management port
 
-The runner exposes port 8080 (Spring Boot Actuator) via a ClusterIP Service.
-This allows external monitoring tools such as Prometheus to scrape metrics
-without exposing the runner publicly. The port is configurable:
+Both GUI and runner expose Spring Boot Actuator on a dedicated management port
+(default **8081**), separate from the main HTTP port 8080. This port starts its
+own HTTP listener that is independent of Spring Security, so health endpoints
+are always reachable by probes regardless of the authentication profile active
+on the main port.
+
+The management port is used for liveness/readiness probes and can also be
+scraped by Prometheus. It is configurable independently per component:
 
 ```yaml
+gui:
+  managementPort: 8081   # default
 runner:
-  service:
-    port: 8080   # default
+  managementPort: 8081   # default
 ```
 
 ## Writable `/tmp` volume
@@ -289,46 +298,45 @@ Disable only if you provide an alternative writable location for `/tmp`.
 
 ## Probes
 
-The GUI and runner liveness and readiness probes support the full Kubernetes
-probe-action set. Each of `gui.probes.liveness`, `gui.probes.readiness`,
-`runner.probes.liveness` and `runner.probes.readiness` accepts one of the
-optional keys `httpGet`, `tcpSocket` or `exec` (passed through verbatim to the
-pod spec). If none is set, the template falls back to the existing `path:`
-shortcut, which performs an `httpGet` against the named `http` port.
+Both components default to `httpGet` probes against the management port (8081).
+Because the management port is a separate HTTP listener that bypasses Spring
+Security, probes work correctly regardless of which authentication profile is
+active — no special probe configuration is needed.
 
-The runner does not expose an HTTP server by default, so `exec` probes are the
-recommended choice there:
+Each probe field (`gui.probes.liveness`, `gui.probes.readiness`,
+`runner.probes.liveness`, `runner.probes.readiness`) accepts any of the
+standard Kubernetes probe actions — `httpGet`, `tcpSocket`, or `exec` — passed
+through verbatim to the pod spec. Override only if you have a specific reason:
 
 ```yaml
+# Example: disable readiness probing entirely for the runner
 runner:
   probes:
-    liveness:
-      exec:
-        command: ["true"]
-      initialDelaySeconds: 30
-      periodSeconds: 30
     readiness:
-      exec:
-        command: ["true"]
-      initialDelaySeconds: 10
-      periodSeconds: 15
+      enabled: false
 ```
 
-The GUI's Spring Security configuration protects `/actuator/**` by default, so
-the `path:` shortcut returns HTTP 401 unless the `noauth` Spring profile is
-active or the health endpoints are explicitly permitted. A `tcpSocket` probe
-avoids this:
+## Subchart usage
+
+When this chart is used as a dependency (subchart) of a wrapper chart, all
+values must be nested under the chart's release name key. For example, if the
+dependency is declared as `name: smartmet-verify`, prefix every parameter from
+this README with `smartmet-verify.`:
 
 ```yaml
-gui:
-  probes:
-    liveness:
-      tcpSocket:
-        port: http
-    readiness:
-      tcpSocket:
-        port: http
+# wrapper chart values.yaml
+smartmet-verify:
+  gui:
+    enabled: true
+    image:
+      tag: "1.2.3"
+  runner:
+    enabled: true
 ```
+
+The [deployment template](https://github.com/fmidev/smartmet-verify-deployment-template)
+follows this pattern — its `values-rke2.yaml` and `values-openshift.yaml` use
+the `smartmet-verify.` prefix throughout.
 
 ## Installation
 
@@ -387,7 +395,7 @@ SQL yourself as an existing ConfigMap and reference it from `database.spec`.
 Create the ConfigMap:
 
 ```shell
-kubectl -n <ns> create configmap verification-db-init-sql \
+kubectl -n smartmet-verify create configmap verification-db-init-sql \
   --from-file=0000-pre-init.sql \
   --from-file=0001-production-schema.sql \
   --from-file=0002-post-ownership.sql

--- a/charts/smartmet-verify/README.md
+++ b/charts/smartmet-verify/README.md
@@ -5,7 +5,7 @@ This Helm chart deploys the **SmartMet Verify** system, consisting of:
 - `fmi-verification-gui` (web application)
 - `fmi-verification-runner` (background processing)
 
-Both applications are deployed independently and can be enabled or disabled as needed.
+Both applications can be deployed together or independently. An optional PostgreSQL/PostGIS database can also be provisioned in the same namespace via the CloudNativePG operator.
 
 ## Overview
 

--- a/charts/smartmet-verify/README.md
+++ b/charts/smartmet-verify/README.md
@@ -64,10 +64,11 @@ or:
 ```shell
 kubectl create -f pull-secret.yaml --namespace=smartmet-verify
 ```
-3. Update Kubernetes configuration:
+3. Update Kubernetes configuration to reference the secret by the name used above
+   (adjust if you chose a different name, e.g. `quay-pull-secret`):
 ```yaml
 imagePullSecrets:
-  - name: put-secret-name-here
+  - name: container-registry-pull-secret
 ```
 
 ### Image registry and tag overrides

--- a/charts/smartmet-verify/README.md
+++ b/charts/smartmet-verify/README.md
@@ -329,12 +329,14 @@ gui:
 
 1. Add Helm repo:
 ```shell
-helm repo add fmidev https://fmidev.github.io/helm-charts
+helm repo add fmi https://fmidev.github.io/helm-charts
 helm repo update
 ```
 2. Install chart:
 ```shell
-helm install smartmet-verify fmidev/smartmet-verify -f values.yaml
+helm install smartmet-verify fmi/smartmet-verify \
+  --namespace smartmet-verify \
+  -f values.yaml
 ```
 
 ## Database (optional)

--- a/charts/smartmet-verify/README.md
+++ b/charts/smartmet-verify/README.md
@@ -49,7 +49,23 @@ The application images are private and hosted in Quay.io
 - `quay.io/fmi/fmi-verification-gui`
 - `quay.io/fmi/fmi-verification-runner`
 
-You must create an image pull secret:
+You must create an image pull secret. The recommended approach is to download the
+pull secret directly from the Quay.io robot account settings:
+
+1. Download the Kubernetes pull secret YAML from the Quay.io robot account settings
+   (e.g. to `pull-secret.yaml`).
+2. Apply it to the cluster:
+```shell
+kubectl create -f pull-secret.yaml --namespace=smartmet-verify
+```
+3. If the secret name in the downloaded file differs from `pull-secret`, update
+   `imagePullSecrets` in your values file accordingly:
+```yaml
+imagePullSecrets:
+  - name: pull-secret
+```
+
+Alternatively (option B), create the secret manually with credentials:
 
 ```shell
 kubectl create secret docker-registry pull-secret \
@@ -58,19 +74,6 @@ kubectl create secret docker-registry pull-secret \
   --docker-password=<PASSWORD> \
   --docker-email=<EMAIL> \
   --namespace=smartmet-verify
-```
-
-or:
-
-1. Download the Kubernetes pull secret for the account (e.g. to `pull-secret.yaml`).
-2. Submit the secret to the cluster:
-```shell
-kubectl create -f pull-secret.yaml --namespace=smartmet-verify
-```
-3. Update Kubernetes configuration to reference the secret by the name used above:
-```yaml
-imagePullSecrets:
-  - name: pull-secret
 ```
 
 ### Image registry and tag overrides
@@ -150,7 +153,7 @@ stringData:
         name: verification
         type: com.zaxxer.hikari.HikariDataSource
         driverClassName: org.postgresql.Driver
-        jdbcUrl: jdbc:postgresql://verification-db.fmi.fi:5432/verifapi
+        jdbcUrl: jdbc:postgresql://verification-db:5432/verifapi
         # readOnly: false is required to enable the result calculation and user UI selection storing from GUI, set this to true if not required
         readOnly: false
         username: verifwww
@@ -166,7 +169,7 @@ stringData:
       supported-language-tags: en-US
       default-language-tag: en-US
     security:
-      require-ssl: true
+      require-ssl: false
       basic:
         enabled: false
       # List of allowed GUI views
@@ -178,7 +181,7 @@ stringData:
       default-redirect: MetadataView
     verification-gui:
       wiki:
-        url: https://wiki.fmi.fi/x/KQCB
+        url: https://wiki.example.com/path/to/documentation
     logging:
       level:
         fi.fmi.verification: INFO
@@ -199,7 +202,7 @@ stringData:
         name: verification
         type: com.zaxxer.hikari.HikariDataSource
         driverClassName: org.postgresql.Driver
-        jdbcUrl: jdbc:postgresql://verification-db.fmi.fi:5432/verifapi
+        jdbcUrl: jdbc:postgresql://verification-db:5432/verifapi
         readOnly: false
         username: verifrun
         password: change-me

--- a/charts/smartmet-verify/README.md
+++ b/charts/smartmet-verify/README.md
@@ -53,7 +53,8 @@ kubectl create secret docker-registry container-registry-pull-secret \
   --docker-server=quay.io \
   --docker-username=<USERNAME> \
   --docker-password=<PASSWORD> \
-  --docker-email=<EMAIL>
+  --docker-email=<EMAIL> \
+  --namespace=smartmet-verify
 ```
 
 or:

--- a/charts/smartmet-verify/README.md
+++ b/charts/smartmet-verify/README.md
@@ -530,6 +530,33 @@ See [`examples/values-rke2.yaml`](./examples/values-rke2.yaml) for a complete
 working database configuration, including managed roles, additional services
 and init SQL wiring.
 
+### External access
+
+By default the database is only reachable within the cluster. To allow
+connections from bare-metal servers or other environments outside the namespace,
+enable the external access Service:
+
+```yaml
+database:
+  externalAccess:
+    enabled: true
+    type: NodePort      # or LoadBalancer
+    # nodePort: 30432   # optional fixed port (NodePort only, 30000–32767)
+```
+
+When `type: NodePort`, clients connect to `<any-node-IP>:<nodePort>` on port 5432.
+When `type: LoadBalancer`, a dedicated external IP is provisioned (requires a
+cloud provider or [MetalLB](https://metallb.universe.tf/) on bare-metal clusters).
+
+The Service name is `<database.name>-external` (e.g. `verification-db-external`)
+and it always routes to the **primary** (read-write) pod.
+
+> **Security note:** direct PostgreSQL exposure over the network should be paired
+> with TLS (CNPG supports server-side TLS via `database.spec.certificates`) and
+> tight `pg_hba.conf` rules (`database.spec.postgresql.pg_hba`) so that only
+> known client IPs and authenticated users are accepted. Consider firewall or
+> network-policy rules in addition.
+
 ## Notes for operators
 
 - Always use Secrets for database credentials
@@ -718,6 +745,10 @@ The following table lists all configurable parameters and their defaults.
 |---|---|---|
 | `database.enabled` | Provision a PostgreSQL/PostGIS database via CloudNativePG | `false` |
 | `database.name` | CNPG `Cluster` name; also the stem of generated services (`<name>-rw`, `-ro`, `-r`) | `verification-db` |
+| `database.externalAccess.enabled` | Expose the database primary outside the cluster via a NodePort or LoadBalancer Service | `false` |
+| `database.externalAccess.type` | Service type: `NodePort` or `LoadBalancer` | `NodePort` |
+| `database.externalAccess.nodePort` | Fixed NodePort number (30000–32767, NodePort only). Omit to auto-assign. | `""` |
+| `database.externalAccess.annotations` | Annotations on the external Service (e.g. MetalLB address pool) | `{}` |
 | `database.spec.instances` | Number of PostgreSQL instances | `1` |
 | `database.spec.imageName` | PostgreSQL + PostGIS container image | `ghcr.io/cloudnative-pg/postgis:16-3.4` |
 | `database.spec.storage.size` | PVC size for database storage | `100Gi` |

--- a/charts/smartmet-verify/README.md
+++ b/charts/smartmet-verify/README.md
@@ -106,11 +106,32 @@ Set `config.mode` for each component independently:
 
 | Mode | Description |
 |------|-------------|
-| `secretFile` | Mount a single file from a Secret (default). Recommended. |
+| `configMapFile` | Mount a single file from a ConfigMap. **Recommended** — keep non-sensitive config in version control; inject only the DB password from a Secret via `extraEnv`. |
+| `secretFile` | Mount a single file from a Secret. Use when the entire config must be opaque. |
 | `env` | Import environment variables from Secrets and/or ConfigMaps. |
 | `none` | No configuration injection. |
 
-#### `secretFile` mode (default)
+#### `configMapFile` mode (recommended)
+
+Store the non-sensitive `application.yaml` in a ConfigMap. Use `${SPRING_DATASOURCE_PASSWORD}`
+as a Spring placeholder — it is resolved at startup from the `SPRING_DATASOURCE_PASSWORD`
+environment variable, which you inject from a separate password-only Secret:
+
+```yaml
+gui:
+  config:
+    mode: configMapFile
+    configMapFile:
+      configMapName: smartmet-verify-gui-config   # must be set
+  extraEnv:
+    - name: SPRING_DATASOURCE_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: smartmet-verify-gui-db-password   # Secret containing only the password
+          key: password
+```
+
+#### `secretFile` mode
 
 Create a Secret containing `application.yaml` and reference it:
 
@@ -120,9 +141,6 @@ gui:
     mode: secretFile
     secretFile:
       secretName: smartmet-verify-gui-config   # must be set
-      secretKey: application.yaml              # key inside the Secret
-      mountPath: /var/app/config
-      fileName: application.yaml
 ```
 
 #### `env` mode
@@ -138,15 +156,18 @@ gui:
         - my-spring-config
 ```
 
-### Example: GUI configuration secret
+### Example: GUI configuration ConfigMap
+
+The `application.yaml` is stored in a ConfigMap. The DB password is a Spring placeholder
+resolved from the `SPRING_DATASOURCE_PASSWORD` env var (injected by the chart via `extraEnv`).
 
 ```yaml
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
   name: smartmet-verify-gui-config
-type: Opaque
-stringData:
+  namespace: smartmet-verify
+data:
   application.yaml: |
     spring:
       datasource:
@@ -157,7 +178,7 @@ stringData:
         # readOnly: false is required to enable the result calculation and user UI selection storing from GUI, set this to true if not required
         readOnly: false
         username: verifwww
-        password: change-me
+        password: "${SPRING_DATASOURCE_PASSWORD}"
         connectionInitSql: SET SESSION TIME ZONE 'UTC'
         poolName: verification
         maximumPoolSize: 5
@@ -187,15 +208,28 @@ stringData:
         fi.fmi.verification: INFO
 ```
 
-### Example: Runner configuration secret
+Password Secret (contains only the DB password):
 
 ```yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: smartmet-verify-runner-config
+  name: smartmet-verify-gui-db-password
+  namespace: smartmet-verify
 type: Opaque
 stringData:
+  password: change-me
+```
+
+### Example: Runner configuration ConfigMap
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: smartmet-verify-runner-config
+  namespace: smartmet-verify
+data:
   application.yaml: |
     spring:
       datasource:
@@ -205,7 +239,7 @@ stringData:
         jdbcUrl: jdbc:postgresql://verification-db:5432/verifapi
         readOnly: false
         username: verifrun
-        password: change-me
+        password: "${SPRING_DATASOURCE_PASSWORD}"
         connectionInitSql: SET SESSION TIME ZONE 'UTC'
         poolName: verification
         maximumPoolSize: 5
@@ -218,6 +252,19 @@ stringData:
     logging:
       level:
         fi.fmi.verification: INFO
+```
+
+Password Secret:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: smartmet-verify-runner-db-password
+  namespace: smartmet-verify
+type: Opaque
+stringData:
+  password: change-me
 ```
 
 ### Full example YAML files
@@ -563,7 +610,11 @@ The following table lists all configurable parameters and their defaults.
 | `gui.extraEnvFrom` | Additional `envFrom` sources | `[]` |
 | `gui.extraVolumes` | Additional volumes | `[]` |
 | `gui.extraVolumeMounts` | Additional volume mounts | `[]` |
-| `gui.config.mode` | Config injection mode: `secretFile`, `env`, or `none` | `secretFile` |
+| `gui.config.mode` | Config injection mode: `configMapFile`, `secretFile`, `env`, or `none` | `secretFile` |
+| `gui.config.configMapFile.configMapName` | ConfigMap containing `application.yaml` — **required** for `configMapFile` mode | `""` |
+| `gui.config.configMapFile.configMapKey` | Key within the ConfigMap | `application.yaml` |
+| `gui.config.configMapFile.mountPath` | Mount path inside the container | `/var/app/config` |
+| `gui.config.configMapFile.fileName` | Filename at mount path | `application.yaml` |
 | `gui.config.secretFile.secretName` | Secret containing `application.yaml` — **required** for `secretFile` mode | `""` |
 | `gui.config.secretFile.secretKey` | Key within the Secret | `application.yaml` |
 | `gui.config.secretFile.mountPath` | Mount path inside the container | `/var/app/config` |
@@ -629,7 +680,11 @@ The following table lists all configurable parameters and their defaults.
 | `runner.extraEnvFrom` | Additional `envFrom` sources | `[]` |
 | `runner.extraVolumes` | Additional volumes | `[]` |
 | `runner.extraVolumeMounts` | Additional volume mounts | `[]` |
-| `runner.config.mode` | Config injection mode: `secretFile`, `env`, or `none` | `secretFile` |
+| `runner.config.mode` | Config injection mode: `configMapFile`, `secretFile`, `env`, or `none` | `secretFile` |
+| `runner.config.configMapFile.configMapName` | ConfigMap containing `application.yaml` — **required** for `configMapFile` mode | `""` |
+| `runner.config.configMapFile.configMapKey` | Key within the ConfigMap | `application.yaml` |
+| `runner.config.configMapFile.mountPath` | Mount path inside the container | `/var/app/config` |
+| `runner.config.configMapFile.fileName` | Filename at mount path | `application.yaml` |
 | `runner.config.secretFile.secretName` | Secret containing `application.yaml` — **required** for `secretFile` mode | `""` |
 | `runner.config.secretFile.secretKey` | Key within the Secret | `application.yaml` |
 | `runner.config.secretFile.mountPath` | Mount path inside the container | `/var/app/config` |

--- a/charts/smartmet-verify/README.md
+++ b/charts/smartmet-verify/README.md
@@ -498,3 +498,167 @@ Check mounted configuration:
 ```shell
 kubectl exec -it <pod> -- ls /var/app/config
 ```
+
+## Chart Configuration
+
+The following table lists all configurable parameters and their defaults.
+
+### Global
+
+| Parameter | Description | Default |
+|---|---|---|
+| `nameOverride` | Override the chart name used in resource names | `""` |
+| `fullnameOverride` | Override the full name used in resource names | `""` |
+| `commonLabels` | Labels added to every resource | `{}` |
+| `commonAnnotations` | Annotations added to every resource | `{}` |
+| `imagePullSecrets` | Image pull secrets for private registries | `[]` |
+| `global.imageRegistry` | Global image registry prefix (overrides per-image registries) | `""` |
+| `global.extraVolumes` | Extra volumes added to all pods | `[]` |
+| `global.extraVolumeMounts` | Extra volume mounts added to all containers | `[]` |
+| `serviceAccount.create` | Create a dedicated ServiceAccount | `true` |
+| `serviceAccount.name` | ServiceAccount name (generated if empty) | `""` |
+| `serviceAccount.annotations` | Annotations for the ServiceAccount | `{}` |
+| `podSecurityContext.fsGroup` | Filesystem group for mounted volumes | `1000` |
+| `securityContext.runAsNonRoot` | Require non-root execution | `true` |
+| `securityContext.runAsUser` | User ID for the container process | `1000` |
+| `securityContext.runAsGroup` | Group ID for the container process | `1000` |
+| `securityContext.allowPrivilegeEscalation` | Allow privilege escalation | `false` |
+| `securityContext.readOnlyRootFilesystem` | Mount root filesystem read-only | `true` |
+| `securityContext.capabilities.drop` | Linux capabilities to drop | `["ALL"]` |
+
+### GUI
+
+| Parameter | Description | Default |
+|---|---|---|
+| `gui.enabled` | Deploy the GUI | `false` |
+| `gui.replicaCount` | Number of GUI pod replicas | `1` |
+| `gui.image.repository` | GUI image repository | `quay.io/fmi/fmi-verification-gui` |
+| `gui.image.tag` | GUI image tag — **required** | `""` |
+| `gui.image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `gui.service.type` | Kubernetes Service type | `ClusterIP` |
+| `gui.service.port` | Service port (main HTTP) | `8080` |
+| `gui.resources.requests.memory` | Memory request | `3Gi` |
+| `gui.resources.requests.cpu` | CPU request | `2` |
+| `gui.resources.limits.memory` | Memory limit | `3Gi` |
+| `gui.resources.limits.cpu` | CPU limit | `2` |
+| `gui.nodeSelector` | Node selector constraints | `{}` |
+| `gui.tolerations` | Pod tolerations | `[]` |
+| `gui.affinity` | Pod affinity rules | `{}` |
+| `gui.podAnnotations` | Annotations added to GUI pods | `{}` |
+| `gui.podLabels` | Labels added to GUI pods | `{}` |
+| `gui.springProfile` | Comma-separated Spring profile(s) to activate | `production` |
+| `gui.env` | Environment variables for the GUI container | see `values.yaml` |
+| `gui.extraEnv` | Additional environment variables | `[]` |
+| `gui.extraEnvFrom` | Additional `envFrom` sources | `[]` |
+| `gui.extraVolumes` | Additional volumes | `[]` |
+| `gui.extraVolumeMounts` | Additional volume mounts | `[]` |
+| `gui.config.mode` | Config injection mode: `secretFile`, `env`, or `none` | `secretFile` |
+| `gui.config.secretFile.secretName` | Secret containing `application.yaml` — **required** for `secretFile` mode | `""` |
+| `gui.config.secretFile.secretKey` | Key within the Secret | `application.yaml` |
+| `gui.config.secretFile.mountPath` | Mount path inside the container | `/var/app/config` |
+| `gui.config.secretFile.fileName` | Filename at mount path | `application.yaml` |
+| `gui.config.envFrom.secretRefs` | Secrets to import as env vars (`env` mode) | `[]` |
+| `gui.config.envFrom.configMapRefs` | ConfigMaps to import as env vars (`env` mode) | `[]` |
+| `gui.persistence.logs.enabled` | Persist Tomcat logs to a PVC | `false` |
+| `gui.persistence.logs.size` | Log PVC size | `5Gi` |
+| `gui.persistence.logs.storageClassName` | Storage class for the log PVC | `""` |
+| `gui.persistence.logs.mountPath` | Log directory mount path | `/var/log/tomcat` |
+| `gui.tmpDir.enabled` | Mount a writable `emptyDir` at `/tmp` (required with read-only root filesystem) | `true` |
+| `gui.managementPort` | Spring Boot Actuator management port | `8081` |
+| `gui.probes.liveness.enabled` | Enable liveness probe | `true` |
+| `gui.probes.liveness.httpGet.path` | Liveness probe HTTP path | `/actuator/health/liveness` |
+| `gui.probes.liveness.httpGet.port` | Liveness probe port | `management` |
+| `gui.probes.liveness.initialDelaySeconds` | Seconds before first liveness check | `30` |
+| `gui.probes.liveness.periodSeconds` | Seconds between liveness checks | `10` |
+| `gui.probes.liveness.timeoutSeconds` | Probe timeout | `3` |
+| `gui.probes.liveness.failureThreshold` | Failures before pod restart | `6` |
+| `gui.probes.readiness.enabled` | Enable readiness probe | `true` |
+| `gui.probes.readiness.httpGet.path` | Readiness probe HTTP path | `/actuator/health/readiness` |
+| `gui.probes.readiness.httpGet.port` | Readiness probe port | `management` |
+| `gui.probes.readiness.initialDelaySeconds` | Seconds before first readiness check | `20` |
+| `gui.probes.readiness.periodSeconds` | Seconds between readiness checks | `10` |
+| `gui.probes.readiness.timeoutSeconds` | Probe timeout | `3` |
+| `gui.probes.readiness.failureThreshold` | Failures before pod marked unready | `6` |
+| `gui.ingress.enabled` | Enable Ingress (Kubernetes / RKE2) | `false` |
+| `gui.ingress.className` | Ingress class name (e.g. `traefik`, `nginx`) | `""` |
+| `gui.ingress.annotations` | Ingress annotations | `{}` |
+| `gui.ingress.customAnnotations` | Additional ingress annotations merged with `annotations` (e.g. `cert-manager.io/cluster-issuer`) | `{}` |
+| `gui.ingress.hosts` | Ingress host rules | see `values.yaml` |
+| `gui.ingress.tls` | Ingress TLS configuration | `[]` |
+| `gui.route.enabled` | Enable OpenShift Route (mutually exclusive with `ingress.enabled`) | `false` |
+| `gui.route.annotations` | Route annotations (e.g. HAProxy IP whitelist) | `{}` |
+| `gui.route.host` | Route hostname | `""` |
+| `gui.route.tls.enabled` | Enable TLS on the Route | `true` |
+| `gui.route.tls.termination` | TLS termination type | `edge` |
+| `gui.route.tls.insecureEdgeTerminationPolicy` | HTTP → HTTPS redirect policy | `Redirect` |
+
+### Runner
+
+| Parameter | Description | Default |
+|---|---|---|
+| `runner.enabled` | Deploy the runner | `false` |
+| `runner.replicaCount` | Number of runner pod replicas | `1` |
+| `runner.image.repository` | Runner image repository | `quay.io/fmi/fmi-verification-runner` |
+| `runner.image.tag` | Runner image tag — **required** | `""` |
+| `runner.image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `runner.service.type` | Kubernetes Service type | `ClusterIP` |
+| `runner.service.port` | Service port | `8080` |
+| `runner.resources.requests.memory` | Memory request | `6Gi` |
+| `runner.resources.requests.cpu` | CPU request | `2` |
+| `runner.resources.limits.memory` | Memory limit | `6Gi` |
+| `runner.resources.limits.cpu` | CPU limit | `2` |
+| `runner.nodeSelector` | Node selector constraints | `{}` |
+| `runner.tolerations` | Pod tolerations | `[]` |
+| `runner.affinity` | Pod affinity rules | `{}` |
+| `runner.podAnnotations` | Annotations added to runner pods | `{}` |
+| `runner.podLabels` | Labels added to runner pods | `{}` |
+| `runner.springProfile` | Comma-separated Spring profile(s) to activate | `production` |
+| `runner.env` | Environment variables for the runner container | see `values.yaml` |
+| `runner.extraEnv` | Additional environment variables | `[]` |
+| `runner.extraEnvFrom` | Additional `envFrom` sources | `[]` |
+| `runner.extraVolumes` | Additional volumes | `[]` |
+| `runner.extraVolumeMounts` | Additional volume mounts | `[]` |
+| `runner.config.mode` | Config injection mode: `secretFile`, `env`, or `none` | `secretFile` |
+| `runner.config.secretFile.secretName` | Secret containing `application.yaml` — **required** for `secretFile` mode | `""` |
+| `runner.config.secretFile.secretKey` | Key within the Secret | `application.yaml` |
+| `runner.config.secretFile.mountPath` | Mount path inside the container | `/var/app/config` |
+| `runner.config.secretFile.fileName` | Filename at mount path | `application.yaml` |
+| `runner.config.envFrom.secretRefs` | Secrets to import as env vars (`env` mode) | `[]` |
+| `runner.config.envFrom.configMapRefs` | ConfigMaps to import as env vars (`env` mode) | `[]` |
+| `runner.persistence.logs.enabled` | Persist Tomcat logs to a PVC | `false` |
+| `runner.persistence.logs.size` | Log PVC size | `5Gi` |
+| `runner.persistence.logs.storageClassName` | Storage class for the log PVC | `""` |
+| `runner.persistence.logs.mountPath` | Log directory mount path | `/var/log/tomcat` |
+| `runner.tmpDir.enabled` | Mount a writable `emptyDir` at `/tmp` | `true` |
+| `runner.managementPort` | Spring Boot Actuator management port | `8081` |
+| `runner.probes.liveness.enabled` | Enable liveness probe | `true` |
+| `runner.probes.liveness.httpGet.path` | Liveness probe HTTP path | `/actuator/health/liveness` |
+| `runner.probes.liveness.httpGet.port` | Liveness probe port | `management` |
+| `runner.probes.liveness.initialDelaySeconds` | Seconds before first liveness check | `30` |
+| `runner.probes.liveness.periodSeconds` | Seconds between liveness checks | `20` |
+| `runner.probes.liveness.timeoutSeconds` | Probe timeout | `3` |
+| `runner.probes.liveness.failureThreshold` | Failures before pod restart | `6` |
+| `runner.probes.readiness.enabled` | Enable readiness probe | `true` |
+| `runner.probes.readiness.httpGet.path` | Readiness probe HTTP path | `/actuator/health/readiness` |
+| `runner.probes.readiness.httpGet.port` | Readiness probe port | `management` |
+| `runner.probes.readiness.initialDelaySeconds` | Seconds before first readiness check | `20` |
+| `runner.probes.readiness.periodSeconds` | Seconds between readiness checks | `20` |
+| `runner.probes.readiness.timeoutSeconds` | Probe timeout | `3` |
+| `runner.probes.readiness.failureThreshold` | Failures before pod marked unready | `6` |
+
+### Database (CloudNativePG)
+
+| Parameter | Description | Default |
+|---|---|---|
+| `database.enabled` | Provision a PostgreSQL/PostGIS database via CloudNativePG | `false` |
+| `database.name` | CNPG `Cluster` name; also the stem of generated services (`<name>-rw`, `-ro`, `-r`) | `verification-db` |
+| `database.spec.instances` | Number of PostgreSQL instances | `1` |
+| `database.spec.imageName` | PostgreSQL + PostGIS container image | `ghcr.io/cloudnative-pg/postgis:16-3.4` |
+| `database.spec.storage.size` | PVC size for database storage | `100Gi` |
+| `database.spec.storage.storageClass` | Storage class for the database PVC | `""` |
+| `database.spec.bootstrap.initdb.database` | Name of the application database to create | `verifapi` |
+| `database.spec.bootstrap.initdb.owner` | Initial database owner role | `app` |
+| `database.spec.bootstrap.initdb.postInitSQLRefs` | ConfigMap/Secret refs for SQL run before app init (e.g. `0000-pre-init.sql`) | `[]` |
+| `database.spec.bootstrap.initdb.postInitApplicationSQLRefs` | ConfigMap/Secret refs for SQL run after app init (e.g. schema + ownership SQL) | `[]` |
+| `database.spec.managed.roles` | CNPG managed roles with passwords from Kubernetes Secrets | `[]` |
+| `database.spec.managed.services.additional` | Extra services (e.g. a `verification-db` alias for the primary) | `[]` |

--- a/charts/smartmet-verify/README.md
+++ b/charts/smartmet-verify/README.md
@@ -423,15 +423,23 @@ Role passwords come from `kubernetes.io/basic-auth` secrets that you create,
 one per managed role:
 
 ```shell
-kubectl -n <ns> create secret generic verification-db-verifwww \
+kubectl -n smartmet-verify create secret generic verification-db-verifadmin \
   --type=kubernetes.io/basic-auth \
-  --from-literal=username=verifwww \
-  --from-literal=password=<strong>
+  --from-literal=username=verifadmin --from-literal=password=<password>
+kubectl -n smartmet-verify create secret generic verification-db-verifwww \
+  --type=kubernetes.io/basic-auth \
+  --from-literal=username=verifwww --from-literal=password=<password>
+kubectl -n smartmet-verify create secret generic verification-db-verifrun \
+  --type=kubernetes.io/basic-auth \
+  --from-literal=username=verifrun --from-literal=password=<password>
+kubectl -n smartmet-verify create secret generic verification-db-verifimport \
+  --type=kubernetes.io/basic-auth \
+  --from-literal=username=verifimport --from-literal=password=<password>
 ```
 
-The same password must also end up in the application config Secret (e.g.
-`smartmet-verify-gui-config`) that the GUI and runner mount. Keep the two in
-sync whenever you rotate a password.
+The `verifwww` and `verifrun` passwords must also appear in the application
+config Secrets (`smartmet-verify-gui-config` and `smartmet-verify-runner-config`
+respectively). Keep the two in sync whenever you rotate a password.
 
 ### Managed role memberships
 

--- a/charts/smartmet-verify/README.md
+++ b/charts/smartmet-verify/README.md
@@ -34,6 +34,9 @@ Before installing:
    - A Kubernetes or OpenShift cluster
    - `kubectl` or `oc` configured
    - `helm` installed
+   - An ingress controller (Kubernetes) or Route support (OpenShift) — RKE2 includes Traefik by default
+   - A DNS record for the GUI hostname pointing to the cluster's ingress IP
+   - [cert-manager](https://cert-manager.io/) with a `letsencrypt` ClusterIssuer for automated TLS (Kubernetes); on OpenShift TLS is handled by the Route
 
 2. You must create:
    - A **pull secret** for Quay.io

--- a/charts/smartmet-verify/examples/values-rke2.yaml
+++ b/charts/smartmet-verify/examples/values-rke2.yaml
@@ -86,7 +86,7 @@ database:
         timezone: UTC
         log_timezone: UTC
     storage:
-      size: 20Gi
+      size: 100Gi
       storageClass: local-path
     bootstrap:
       initdb:

--- a/charts/smartmet-verify/templates/database-external-service.yaml
+++ b/charts/smartmet-verify/templates/database-external-service.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.database.enabled .Values.database.externalAccess.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.database.name }}-external
+  labels:
+    {{- include "smartmet-verify.componentLabels" (list . "database") | nindent 4 }}
+  {{- with .Values.database.externalAccess.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.database.externalAccess.type }}
+  selector:
+    cnpg.io/cluster: {{ .Values.database.name }}
+    cnpg.io/instanceRole: primary
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
+      {{- if and (eq .Values.database.externalAccess.type "NodePort") .Values.database.externalAccess.nodePort }}
+      nodePort: {{ .Values.database.externalAccess.nodePort }}
+      {{- end }}
+{{- end }}

--- a/charts/smartmet-verify/templates/gui-deployment.yaml
+++ b/charts/smartmet-verify/templates/gui-deployment.yaml
@@ -43,6 +43,9 @@ spec:
             - name: http
               containerPort: {{ .Values.gui.service.port }}
               protocol: TCP
+            - name: management
+              containerPort: {{ .Values.gui.managementPort }}
+              protocol: TCP
           {{- $env := concat .Values.gui.env .Values.gui.extraEnv }}
           {{- if $env }}
           env:

--- a/charts/smartmet-verify/templates/gui-deployment.yaml
+++ b/charts/smartmet-verify/templates/gui-deployment.yaml
@@ -79,12 +79,19 @@ spec:
           resources:
             {{- toYaml .Values.gui.resources | nindent 12 }}
           {{- $hasConfigMount := and (eq .Values.gui.config.mode "secretFile") .Values.gui.config.secretFile.secretName }}
-          {{- if or $hasConfigMount .Values.gui.tmpDir.enabled .Values.gui.persistence.logs.enabled .Values.global.extraVolumeMounts .Values.gui.extraVolumeMounts }}
+          {{- $hasConfigMapMount := and (eq .Values.gui.config.mode "configMapFile") .Values.gui.config.configMapFile.configMapName }}
+          {{- if or $hasConfigMount $hasConfigMapMount .Values.gui.tmpDir.enabled .Values.gui.persistence.logs.enabled .Values.global.extraVolumeMounts .Values.gui.extraVolumeMounts }}
           volumeMounts:
             {{- if $hasConfigMount }}
             - name: gui-config
               mountPath: {{ printf "%s/%s" .Values.gui.config.secretFile.mountPath .Values.gui.config.secretFile.fileName }}
               subPath: {{ .Values.gui.config.secretFile.secretKey }}
+              readOnly: true
+            {{- end }}
+            {{- if $hasConfigMapMount }}
+            - name: gui-config
+              mountPath: {{ printf "%s/%s" .Values.gui.config.configMapFile.mountPath .Values.gui.config.configMapFile.fileName }}
+              subPath: {{ .Values.gui.config.configMapFile.configMapKey }}
               readOnly: true
             {{- end }}
             {{- if .Values.gui.tmpDir.enabled }}
@@ -102,12 +109,20 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if or $hasConfigMount .Values.gui.tmpDir.enabled .Values.gui.persistence.logs.enabled .Values.global.extraVolumes .Values.gui.extraVolumes }}
+      {{- if or $hasConfigMount $hasConfigMapMount .Values.gui.tmpDir.enabled .Values.gui.persistence.logs.enabled .Values.global.extraVolumes .Values.gui.extraVolumes }}
       volumes:
         {{- if $hasConfigMount }}
         - name: gui-config
           secret:
             secretName: {{ .Values.gui.config.secretFile.secretName }}
+        {{- end }}
+        {{- if $hasConfigMapMount }}
+        - name: gui-config
+          configMap:
+            name: {{ .Values.gui.config.configMapFile.configMapName }}
+            items:
+              - key: {{ .Values.gui.config.configMapFile.configMapKey }}
+                path: {{ .Values.gui.config.configMapFile.fileName }}
         {{- end }}
         {{- if .Values.gui.tmpDir.enabled }}
         - name: tmp

--- a/charts/smartmet-verify/templates/gui-deployment.yaml
+++ b/charts/smartmet-verify/templates/gui-deployment.yaml
@@ -46,7 +46,8 @@ spec:
             - name: management
               containerPort: {{ .Values.gui.managementPort }}
               protocol: TCP
-          {{- $env := concat .Values.gui.env .Values.gui.extraEnv }}
+          {{- $springProfileEnv := list (dict "name" "SPRING_PROFILES_ACTIVE" "value" .Values.gui.springProfile) }}
+          {{- $env := concat $springProfileEnv .Values.gui.env .Values.gui.extraEnv }}
           {{- if $env }}
           env:
             {{- toYaml $env | nindent 12 }}

--- a/charts/smartmet-verify/templates/gui-ingress.yaml
+++ b/charts/smartmet-verify/templates/gui-ingress.yaml
@@ -8,7 +8,8 @@ metadata:
   name: {{ include "smartmet-verify.componentFullname" (list . "gui") }}
   labels:
     {{- include "smartmet-verify.componentLabels" (list . "gui") | nindent 4 }}
-  {{- with .Values.gui.ingress.annotations }}
+  {{- $annotations := merge (.Values.gui.ingress.customAnnotations | default dict) (.Values.gui.ingress.annotations | default dict) }}
+  {{- with $annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/smartmet-verify/templates/runner-deployment.yaml
+++ b/charts/smartmet-verify/templates/runner-deployment.yaml
@@ -43,6 +43,9 @@ spec:
             - name: http
               containerPort: {{ .Values.runner.service.port }}
               protocol: TCP
+            - name: management
+              containerPort: {{ .Values.runner.managementPort }}
+              protocol: TCP
           {{- $env := concat .Values.runner.env .Values.runner.extraEnv }}
           {{- if $env }}
           env:

--- a/charts/smartmet-verify/templates/runner-deployment.yaml
+++ b/charts/smartmet-verify/templates/runner-deployment.yaml
@@ -79,12 +79,19 @@ spec:
           resources:
             {{- toYaml .Values.runner.resources | nindent 12 }}
           {{- $hasConfigMount := and (eq .Values.runner.config.mode "secretFile") .Values.runner.config.secretFile.secretName }}
-          {{- if or $hasConfigMount .Values.runner.tmpDir.enabled .Values.runner.persistence.logs.enabled .Values.global.extraVolumeMounts .Values.runner.extraVolumeMounts }}
+          {{- $hasConfigMapMount := and (eq .Values.runner.config.mode "configMapFile") .Values.runner.config.configMapFile.configMapName }}
+          {{- if or $hasConfigMount $hasConfigMapMount .Values.runner.tmpDir.enabled .Values.runner.persistence.logs.enabled .Values.global.extraVolumeMounts .Values.runner.extraVolumeMounts }}
           volumeMounts:
             {{- if $hasConfigMount }}
             - name: runner-config
               mountPath: {{ printf "%s/%s" .Values.runner.config.secretFile.mountPath .Values.runner.config.secretFile.fileName }}
               subPath: {{ .Values.runner.config.secretFile.secretKey }}
+              readOnly: true
+            {{- end }}
+            {{- if $hasConfigMapMount }}
+            - name: runner-config
+              mountPath: {{ printf "%s/%s" .Values.runner.config.configMapFile.mountPath .Values.runner.config.configMapFile.fileName }}
+              subPath: {{ .Values.runner.config.configMapFile.configMapKey }}
               readOnly: true
             {{- end }}
             {{- if .Values.runner.tmpDir.enabled }}
@@ -102,12 +109,20 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if or $hasConfigMount .Values.runner.tmpDir.enabled .Values.runner.persistence.logs.enabled .Values.global.extraVolumes .Values.runner.extraVolumes }}
+      {{- if or $hasConfigMount $hasConfigMapMount .Values.runner.tmpDir.enabled .Values.runner.persistence.logs.enabled .Values.global.extraVolumes .Values.runner.extraVolumes }}
       volumes:
         {{- if $hasConfigMount }}
         - name: runner-config
           secret:
             secretName: {{ .Values.runner.config.secretFile.secretName }}
+        {{- end }}
+        {{- if $hasConfigMapMount }}
+        - name: runner-config
+          configMap:
+            name: {{ .Values.runner.config.configMapFile.configMapName }}
+            items:
+              - key: {{ .Values.runner.config.configMapFile.configMapKey }}
+                path: {{ .Values.runner.config.configMapFile.fileName }}
         {{- end }}
         {{- if .Values.runner.tmpDir.enabled }}
         - name: tmp

--- a/charts/smartmet-verify/templates/runner-deployment.yaml
+++ b/charts/smartmet-verify/templates/runner-deployment.yaml
@@ -46,7 +46,8 @@ spec:
             - name: management
               containerPort: {{ .Values.runner.managementPort }}
               protocol: TCP
-          {{- $env := concat .Values.runner.env .Values.runner.extraEnv }}
+          {{- $springProfileEnv := list (dict "name" "SPRING_PROFILES_ACTIVE" "value" .Values.runner.springProfile) }}
+          {{- $env := concat $springProfileEnv .Values.runner.env .Values.runner.extraEnv }}
           {{- if $env }}
           env:
             {{- toYaml $env | nindent 12 }}

--- a/charts/smartmet-verify/values.yaml
+++ b/charts/smartmet-verify/values.yaml
@@ -278,6 +278,17 @@ database:
   # `database.spec.managed.services.additional`.
   name: verification-db
 
+  # Expose the database primary outside the cluster so that bare-metal servers
+  # or other environments outside the namespace can connect directly.
+  # Disabled by default — enable only when external PostgreSQL access is needed.
+  externalAccess:
+    enabled: false
+    # NodePort — works on any cluster; connects via <any-node-IP>:<nodePort>.
+    # LoadBalancer — requires a cloud provider or MetalLB; gets a dedicated external IP.
+    type: NodePort
+    # nodePort: 30432  # Specific port in range 30000–32767 (NodePort only). Omit to auto-assign.
+    annotations: {}  # e.g. metallb.universe.tf/address-pool: "default"
+
   spec:
     instances: 1
     imageName: ghcr.io/cloudnative-pg/postgis:16-3.4

--- a/charts/smartmet-verify/values.yaml
+++ b/charts/smartmet-verify/values.yaml
@@ -104,20 +104,28 @@ gui:
   tmpDir:
     enabled: true
 
-  # Probe action. By default this is an httpGet against `path` on the named
-  # `http` port. Set one of `httpGet`, `tcpSocket` or `exec` to use a different
-  # action — those override the `path` shortcut when present.
+  # Spring Boot Actuator management port. The app exposes /actuator/health on
+  # this port (separate from the main HTTP port so Spring Security does not
+  # apply). Must match management.server.port in the app's application.yaml.
+  managementPort: 8081
+
+  # Probe action. By default httpGet against the management port.
+  # Set one of `httpGet`, `tcpSocket` or `exec` to override.
   probes:
     liveness:
       enabled: true
-      path: /actuator/health/liveness
+      httpGet:
+        path: /actuator/health/liveness
+        port: management
       initialDelaySeconds: 30
       periodSeconds: 10
       timeoutSeconds: 3
       failureThreshold: 6
     readiness:
       enabled: true
-      path: /actuator/health/readiness
+      httpGet:
+        path: /actuator/health/readiness
+        port: management
       initialDelaySeconds: 20
       periodSeconds: 10
       timeoutSeconds: 3
@@ -209,19 +217,27 @@ runner:
   tmpDir:
     enabled: true
 
-  # The runner has no HTTP server by default, so probe overrides are common.
-  # See the `exec` / `tcpSocket` / `httpGet` examples in values-rke2.yaml.
+  # Spring Boot Actuator management port. Must match management.server.port
+  # in the app's application.yaml.
+  managementPort: 8081
+
+  # Probe action. By default httpGet against the management port.
+  # Set one of `httpGet`, `tcpSocket` or `exec` to override.
   probes:
     liveness:
       enabled: true
-      path: /actuator/health/liveness
+      httpGet:
+        path: /actuator/health/liveness
+        port: management
       initialDelaySeconds: 30
       periodSeconds: 20
       timeoutSeconds: 3
       failureThreshold: 6
     readiness:
       enabled: true
-      path: /actuator/health/readiness
+      httpGet:
+        path: /actuator/health/readiness
+        port: management
       initialDelaySeconds: 20
       periodSeconds: 20
       timeoutSeconds: 3

--- a/charts/smartmet-verify/values.yaml
+++ b/charts/smartmet-verify/values.yaml
@@ -61,13 +61,15 @@ gui:
   podAnnotations: {}
   podLabels: {}
 
+  springProfile: production
+
   env:
     - name: TZ
       value: "UTC"
     - name: JAVA_TOOL_OPTIONS
       value: "-DproductionMode=true -Dvaadin.productionMode -XX:ActiveProcessorCount=2"
     - name: JAVA_OPTS
-      value: "-Duser.timezone=UTC -Dspring.profiles.active=production -Dspring.config.additional-location=/var/app/config/"
+      value: "-Duser.timezone=UTC -Dspring.config.additional-location=/var/app/config/"
   extraEnv: []
   extraEnvFrom: []
   extraVolumes: []
@@ -180,13 +182,15 @@ runner:
   podAnnotations: {}
   podLabels: {}
 
+  springProfile: production
+
   env:
     - name: TZ
       value: "UTC"
     - name: JAVA_TOOL_OPTIONS
       value: "-DproductionMode=true -XX:ActiveProcessorCount=2"
     - name: JAVA_OPTS
-      value: "-Duser.timezone=UTC -Dspring.profiles.active=production -Dspring.config.additional-location=/var/app/config/"
+      value: "-Duser.timezone=UTC -Dspring.config.additional-location=/var/app/config/"
   extraEnv: []
   extraEnvFrom: []
   extraVolumes: []

--- a/charts/smartmet-verify/values.yaml
+++ b/charts/smartmet-verify/values.yaml
@@ -137,6 +137,7 @@ gui:
     enabled: false
     className: ""
     annotations: {}
+    customAnnotations: {}
     hosts:
       - host: smartmet-verify-gui.local
         paths:

--- a/charts/smartmet-verify/values.yaml
+++ b/charts/smartmet-verify/values.yaml
@@ -77,14 +77,22 @@ gui:
 
   config:
     # Supported modes:
-    # - secretFile: mount one file from a Secret, e.g. application.yaml
-    # - env: import env vars from Secret/ConfigMap
-    # - none: do nothing
+    # - secretFile:    mount one file from a Secret (recommended when full config is sensitive)
+    # - configMapFile: mount one file from a ConfigMap (recommended when only the DB password
+    #                  is sensitive; inject the password via extraEnv from a separate Secret)
+    # - env:           import env vars from Secret/ConfigMap
+    # - none:          do nothing
     mode: secretFile
 
     secretFile:
       secretName: ""
       secretKey: application.yaml
+      mountPath: /var/app/config
+      fileName: application.yaml
+
+    configMapFile:
+      configMapName: ""
+      configMapKey: application.yaml
       mountPath: /var/app/config
       fileName: application.yaml
 
@@ -203,6 +211,12 @@ runner:
     secretFile:
       secretName: ""
       secretKey: application.yaml
+      mountPath: /var/app/config
+      fileName: application.yaml
+
+    configMapFile:
+      configMapName: ""
+      configMapKey: application.yaml
       mountPath: /var/app/config
       fileName: application.yaml
 

--- a/charts/smartmet-verify/values.yaml
+++ b/charts/smartmet-verify/values.yaml
@@ -278,7 +278,7 @@ database:
         log_timezone: UTC
 
     storage:
-      size: 20Gi
+      size: 100Gi
       # storageClass: ""
 
     # By keeping `owner: app` the operator creates a throw-away `app` role,

--- a/charts/smartmet-verify/values.yaml
+++ b/charts/smartmet-verify/values.yaml
@@ -7,7 +7,7 @@ commonAnnotations: {}
 imagePullSecrets: []
 # Example:
 # imagePullSecrets:
-#   - name: container-registry-pull-secret
+#   - name: pull-secret
 
 serviceAccount:
   create: true


### PR DESCRIPTION
## Summary

- **Management port probes**: GUI and runner now expose Spring Boot Actuator on port 8081 (`management.server.port`); liveness and readiness probes use this port via a named `management` container port
- **Configurable Spring profile**: `gui.springProfile` and `runner.springProfile` values (default `production`) injected as `SPRING_PROFILES_ACTIVE`; removes hardcoded profile from `JAVA_OPTS` so deployments can pass a comma-separated list (e.g. `production,international`)
- **Ingress `customAnnotations`**: new `gui.ingress.customAnnotations` field merged with `annotations`, intended for cert-manager and similar annotations
- **Default DB storage**: changed from 20Gi to 100Gi
- **Docs**: prerequisites updated with ingress controller, cert-manager, and DNS requirements; namespace standardised to `smartmet-verify`; DB role secret commands complete with all four users and password-sync note; Chart Configuration reference table added; `helm repo add` alias changed to `fmi`

## Test plan

- [ ] `helm lint charts/smartmet-verify`
- [ ] `helm template` renders probes on port `management` (8081) for both GUI and runner
- [ ] `helm template` with `gui.springProfile: production,international` sets `SPRING_PROFILES_ACTIVE` correctly and `JAVA_OPTS` does not contain a profile flag
- [ ] `helm template` with `gui.ingress.customAnnotations` merges annotations onto the Ingress resource
- [ ] Deploy to a test RKE2 cluster and confirm actuator health endpoints respond on 8081

🤖 Generated with [Claude Code](https://claude.ai/claude-code)