### PR TITLE
feat(smartmetserver): make /smartmet/data volume optional

### DIFF
--- a/charts/smartmetserver/Chart.yaml
+++ b/charts/smartmetserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: smartmetserver
 description: A Helm chart to deploy SmartMet Server for Kubernetes
 type: application
-version: 1.9.10
+version: 1.9.11
 appVersion: "26.01.14"
 home: https://github.com/fmidev/helm-charts
 sources:

--- a/charts/smartmetserver/docs/avi-only-deployment.md
+++ b/charts/smartmetserver/docs/avi-only-deployment.md
@@ -27,7 +27,13 @@ The default `fmidev/smartmetserver` image:
   pointer` / `double free or corruption (out)` immediately after the
   geonames admin handler registers, regardless of avidb data state.
   The bug was implicitly fixed by `26.02.09`. Use **`26.02.09` or
-  newer** (the example values pin `26.03.19`).
+  newer** (the example values pin `26.05.07`).
+
+The image already ships `/smartmet/data/` with empty subdirectories for
+each forecast model (`gfs`, `meps`, `ecmwf`, …) — fine as-is for
+AVI-only setups. Set `volume.type: none` (chart 1.9.11+) so the chart
+does not mount anything over `/smartmet/data` and the image's tree is
+left intact.
 
 ## 2. Helm values
 

--- a/charts/smartmetserver/examples/values-avi-only.yaml
+++ b/charts/smartmetserver/examples/values-avi-only.yaml
@@ -10,8 +10,8 @@
 # external values file. Override `ingress.hosts` for your own host name.
 
 image:
-  # Older tags hit a memory bug at avi-engine init; use 26.03.19 or newer.
-  tag: "26.03.19"
+  # Tags before 26.02.09 hit a multi-engine init heap-corruption bug.
+  tag: "26.05.07"
 
 smartmetserver:
   replicas: 1
@@ -30,14 +30,11 @@ smartmetserver:
     limits:   { cpu: "1",    memory: 2Gi   }
     requests: { cpu: "200m", memory: 512Mi }
 
-# /smartmet/data is required by the chart even when only avi is in use.
-# directHostPath + DirectoryOrCreate is the simplest way to satisfy
-# that without provisioning a PV.
+# AVI-only deployments don't need /smartmet/data — the image already
+# ships an empty model-subdir tree there, which is what querydata sees
+# when no real data is supplied. "none" leaves the image's tree alone.
 volume:
-  type: directHostPath
-  directHostPath:
-    path: /tmp/smartmet-data
-    type: DirectoryOrCreate
+  type: none
 
 hpa:
   minReplicas: 1

--- a/charts/smartmetserver/templates/deployment.yaml
+++ b/charts/smartmetserver/templates/deployment.yaml
@@ -33,9 +33,11 @@ spec:
         ports:
         - containerPort: {{ .Values.smartmetserver.containerPort }}
         volumeMounts:
+        {{- if ne (.Values.volume.type | default "none") "none" }}
         - mountPath: "/smartmet/data"
           name: smartmetserver-volume
           readOnly: {{ .Values.volume.readOnly }}
+        {{- end }}
         - mountPath: "/etc/smartmet/smartmet.conf"
           subPath: "smartmet.conf"
           name: smartmet-configuration
@@ -86,25 +88,30 @@ spec:
           {{- toYaml .Values.smartmetserver.resources | nindent 10 }}
         {{- end }}
       volumes:
+      {{- $volType := .Values.volume.type | default "none" }}
+      {{- if ne $volType "none" }}
       - name: smartmetserver-volume
-        {{- if eq .Values.volume.type "cephfs" }}
+        {{- if eq $volType "cephfs" }}
         persistentVolumeClaim:
           claimName: {{ .Values.volume.cephfs.pvc.name }}
-        {{- else if eq .Values.volume.type "nfs" }}
+        {{- else if eq $volType "nfs" }}
         nfs:
           server: {{ .Values.volume.nfs.server }}
           path: {{ .Values.volume.nfs.path }}
           readOnly: {{ .Values.volume.readOnly }}
-        {{- else if eq .Values.volume.type "hostPath" }}
+        {{- else if eq $volType "hostPath" }}
         persistentVolumeClaim:
           claimName: {{ .Values.volume.hostPath.pvc.name }}
-        {{- else if eq .Values.volume.type "directHostPath" }}
+        {{- else if eq $volType "directHostPath" }}
         hostPath:
           path: {{ .Values.volume.directHostPath.path | quote }}
           type: {{ .Values.volume.directHostPath.type | default "Directory" }}
+        {{- else if eq $volType "emptyDir" }}
+        emptyDir: {}
         {{- else }}
-        {{- fail "volume.type must be one of: cephfs, nfs, hostPath, directHostPath" }}
+        {{- fail "volume.type must be one of: none, emptyDir, cephfs, nfs, hostPath, directHostPath" }}
         {{- end }}
+      {{- end }}
       - name: smartmet-configuration
         configMap:
           name: {{ include "smartmetserver.fullname" . }}-config

--- a/charts/smartmetserver/values.yaml
+++ b/charts/smartmetserver/values.yaml
@@ -103,9 +103,19 @@ ingress:
 
 # Volume configuration for smartmet data
 volume:
-  # Volume type: "cephfs", "nfs", "hostPath", or "directHostPath"
-  # Use "directHostPath" for testing: mounts a node directory directly
-  # without PV/PVC (e.g. /smartmet/data)
+  # Volume type. Controls what is mounted at /smartmet/data inside the
+  # container.
+  #   "none"           - do not mount anything; the image's bundled
+  #                      /smartmet/data tree (with model subdirs:
+  #                      gfs, meps, ecmwf, ...) is left intact. Use this
+  #                      for AVI-only deployments and any setup where
+  #                      you don't supply real querydata files.
+  #   "emptyDir"       - empty pod-local scratch directory, hides the
+  #                      image's tree but is writable.
+  #   "cephfs"         - PVC-backed CephFS mount (see cephfs:* below).
+  #   "nfs"            - direct NFS mount (see nfs:* below).
+  #   "hostPath"       - PV/PVC-backed hostPath (see hostPath:* below).
+  #   "directHostPath" - direct hostPath, no PV/PVC (testing).
   type: hostPath
   # Whether the volume should be mounted as read-only
   readOnly: true


### PR DESCRIPTION
## Summary

Adds two new \`volume.type\` values that solve the long-standing pain
point of having to mount *something* at \`/smartmet/data\` even when the
deployment does not need it (AVI-only, observation-only, any setup
without real querydata files):

- **\`none\`** — no volume mount, no volume entry. The pod sees the
  image's bundled \`/smartmet/data/\` tree (with empty per-model
  subdirectories \`gfs\`, \`meps\`, \`ecmwf\`, ...) instead of an empty
  hostPath/PV that masks them.
- **\`emptyDir\`** — simple pod-local scratch dir; hides the image's
  tree but is writable.

Existing types (\`cephfs\`, \`nfs\`, \`hostPath\`, \`directHostPath\`) and
the default \`hostPath\` are unchanged — purely additive. The PV/PVC
templates were already gated by \`volume.type\` so they correctly skip
for \`none\`/\`emptyDir\`.

## Bonus

- \`examples/values-avi-only.yaml\` switches to \`volume.type: none\`.
- \`docs/avi-only-deployment.md\` documents the new option and notes
  the image's bundled directory tree.
- Example image tag bumped \`26.03.19\` → \`26.05.07\` (the latest
  published \`fmidev/smartmetserver\` tag, verified to boot cleanly with
  the AVI engine + EDR plugin against a populated avidb on a microk8s
  test cluster).

Bumps chart \`1.9.10\` → \`1.9.11\`.

## Test plan

- [x] \`helm lint charts/smartmetserver/\` passes
- [x] \`helm template -s templates/deployment.yaml --set volume.type=none\` — no \`smartmetserver-volume\` mount or volume entry
- [x] \`--set volume.type=emptyDir\` — \`emptyDir: {}\` volume rendered, mount present
- [x] \`--set volume.type=cephfs|hostPath|nfs|directHostPath\` — unchanged from current chart
- [x] End-to-end: chart installed with \`volume.type: none\` against image \`26.05.07\` on microk8s, AVI engine + EDR plugin reachable, \`/edr/collections\` returns \`metar\`/\`taf\`/\`sigmet\`
- [ ] CI \`ct lint\` / \`ct install\` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)