### PR TITLE
fix: correct postInitApplicationSQLRefs order (schema before ownership)

### DIFF
--- a/charts/smartmet-verify/Chart.yaml
+++ b/charts/smartmet-verify/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: smartmet-verify
 description: Helm chart for deploying SmartMet Verify applications (GUI and runner)
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "0.1.0"
 home: https://github.com/fmidev/helm-charts
 sources:

--- a/charts/smartmet-verify/README.md
+++ b/charts/smartmet-verify/README.md
@@ -463,12 +463,12 @@ database:
             - { name: verification-db-init-sql, key: 0000-pre-init.sql }
         postInitApplicationSQLRefs:
           configMapRefs:
-            - { name: verification-db-init-sql, key: 0002-post-ownership.sql }
             - { name: verification-db-init-sql, key: 0001-production-schema.sql }
+            - { name: verification-db-init-sql, key: 0002-post-ownership.sql }
 ```
 
 `0002-post-ownership.sql` is a small user-supplied wrapper that transfers the
-application database's ownership to `verifadmin` before the schema loads. It is
+application database's ownership to `verifadmin` after the schema loads. It is
 needed because the CNPG initdb `owner: app` default avoids conflicting with the
 `CREATE ROLE verifadmin` in `0000-pre-init.sql`, so ownership has to be handed
 over explicitly. Example contents:

--- a/charts/smartmet-verify/examples/values-rke2.yaml
+++ b/charts/smartmet-verify/examples/values-rke2.yaml
@@ -90,9 +90,9 @@ database:
         postInitApplicationSQLRefs:
           configMapRefs:
             - name: verification-db-init-sql
-              key: 0002-post-ownership.sql
-            - name: verification-db-init-sql
               key: 0001-production-schema.sql
+            - name: verification-db-init-sql
+              key: 0002-post-ownership.sql
     managed:
       roles:
         - name: verifadmin

--- a/charts/smartmet-verify/values.yaml
+++ b/charts/smartmet-verify/values.yaml
@@ -324,9 +324,9 @@ database:
         postInitApplicationSQLRefs:
           configMapRefs: []
           # - name: verification-db-init-sql
-          #   key: 0002-post-ownership.sql
-          # - name: verification-db-init-sql
           #   key: 0001-production-schema.sql
+          # - name: verification-db-init-sql
+          #   key: 0002-post-ownership.sql
 
     # managed.roles and managed.services below give applications access to the
     # DB under their expected role names and service hostnames.


### PR DESCRIPTION
## Summary

`0002-post-ownership.sql` runs **after** `0001-production-schema.sql` in Docker because init scripts in `/docker-entrypoint-initdb.d/` execute in lexicographic order. The CNPG example and values had them in the opposite order (`0002` before `0001`), and the README said "before the schema loads".

The SQL in `0002-post-ownership.sql` is order-independent (it only touches database/schema ownership and grants, not schema objects), so this is a consistency fix rather than a functional one. Both `values.yaml`, `examples/values-rke2.yaml`, and `README.md` are corrected.

## Test plan

- [ ] `helm lint` passes
- [ ] No functional change — statements in `0002-post-ownership.sql` work correctly in either order

🤖 Generated with [Claude Code](https://claude.com/claude-code)