### PR TITLE
PAK 7276 - pak-cronjob PVC support

### DIFF
--- a/charts/fmi-cronjobs/Chart.yaml
+++ b/charts/fmi-cronjobs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fmi-cronjobs
 description: Helm chart for defining multiple CronJobs
 type: application
-version: 0.1.0
+version: 0.2.0
 keywords:
   - fmi
   - cronjob

--- a/charts/fmi-cronjobs/README.md
+++ b/charts/fmi-cronjobs/README.md
@@ -10,7 +10,7 @@ Install standalone or add as a dependency to another chart:
 # Chart.yaml
 dependencies:
   - name: fmi-cronjobs
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "https://fmidev.github.io/helm-charts"
 ```
 
@@ -49,6 +49,27 @@ Optional shared defaults applied to every job. Per-job settings always take prec
 | `successfulJobsHistoryLimit` | Successful job records to keep | `1` |
 | `failedJobsHistoryLimit` | Failed job records to keep | `3` |
 | `resourcePreset` | Default resource preset (`minimal`, `normal`, `custom`) | — |
+
+### `pvcs`
+
+Optional list of PersistentVolumeClaims to create. Once created, any job can reference them by `claimName` in its `pvcMounts`. 
+
+| Field | Description | Required |
+|-------|-------------|----------|
+| `name` | PVC name | Yes |
+| `accessModes` | List of access modes (e.g. `[ReadWriteMany]`) | Yes |
+| `size` | Storage request (e.g. `10Gi`) | Yes |
+| `storageClassName` | Storage class to use; omit to use `ocs-storagecluster-cephfs` as default | No |
+| `annotations` | Extra annotations on the PVC metadata | No |
+| `volumeName` | Bind to a specific PersistentVolume by name | No |
+
+```yaml
+pvcs:
+  - name: my-cronjob-pvc
+    accessModes: [ReadWriteMany]
+    size: 10Gi
+    storageClassName: ocs-storagecluster-cephfs
+```
 
 ### `jobs`
 
@@ -154,6 +175,33 @@ mounts:
     subPath: subdir
 ```
 
+### `pvcMounts`
+
+List of PersistentVolumeClaim volume mounts. Reference a PVC by its `claimName` — either one created by the `pvcs` list in this chart or a pre-existing claim in the namespace. Volumes default to read-write unless `readOnly: true` is set explicitly.
+
+| Field | Description | Required |
+|-------|-------------|----------|
+| `name` | Volume name | Yes |
+| `claimName` | Name of the PersistentVolumeClaim to mount | Yes |
+| `mountPath` | Path inside the container | Yes |
+| `readOnly` | Mount as read-only | No (default: `false`) |
+| `subPath` | Sub-path within the volume to mount | No |
+
+```yaml
+pvcMounts:
+  - name: shared-data
+    claimName: my-cronjob-pvc
+    mountPath: /data
+  - name: config-volume
+    claimName: config-pvc
+    mountPath: /config
+    readOnly: true
+  - name: partitioned
+    claimName: my-cronjob-pvc
+    mountPath: /data/subset
+    subPath: subset
+```
+
 ### `tmp`
 
 Mount an `emptyDir` volume as a writable scratch space:
@@ -177,6 +225,12 @@ fmi-cronjobs:
     backoffLimit: 2
     resourcePreset: minimal
 
+  pvcs:
+    - name: my-batch-job-pvc
+      accessModes: [ReadWriteMany]
+      size: 10Gi
+      storageClassName: ocs-storagecluster-cephfs
+
   jobs:
     - name: my-batch-job
       enabled: true
@@ -199,6 +253,10 @@ fmi-cronjobs:
           mountPath: /input
           server: nfs.example.com
           serverPath: /exports/input
+      pvcMounts:
+        - name: output
+          claimName: my-batch-job-pvc
+          mountPath: /output
       tmp:
         enabled: true
         mountPath: /tmp

--- a/charts/fmi-cronjobs/README.md
+++ b/charts/fmi-cronjobs/README.md
@@ -10,7 +10,7 @@ Install standalone or add as a dependency to another chart:
 # Chart.yaml
 dependencies:
   - name: fmi-cronjobs
-    version: "0.1.1"
+    version: "0.2.0"
     repository: "https://fmidev.github.io/helm-charts"
 ```
 
@@ -177,7 +177,7 @@ mounts:
 
 ### `pvcMounts`
 
-List of PersistentVolumeClaim volume mounts. Reference a PVC by its `claimName` — either one created by the `pvcs` list in this chart or a pre-existing claim in the namespace. Volumes default to read-write unless `readOnly: true` is set explicitly.
+List of PersistentVolumeClaim volume mounts. Reference a PVC by its `claimName`. Volumes default to read-write unless `readOnly: true` is set explicitly.
 
 | Field | Description | Required |
 |-------|-------------|----------|

--- a/charts/fmi-cronjobs/templates/_helpers.tpl
+++ b/charts/fmi-cronjobs/templates/_helpers.tpl
@@ -51,16 +51,17 @@ resources:
 {{- end -}}
 
 {{/*
-Render all volumes: NFS mounts + optional tmp emptyDir
+Render all volumes: NFS mounts + PVC mounts + optional tmp emptyDir
 Usage from a manifest:
-  {{ include "fmi-cronjobs.renderVolumes" (dict "mounts" ($job.mounts | default (list)) "tmp" ($job.tmp | default (dict))) | nindent 10 }}
+  {{ include "fmi-cronjobs.renderVolumes" (dict "mounts" ($job.mounts | default (list)) "pvcMounts" ($job.pvcMounts | default (list)) "tmp" ($job.tmp | default (dict))) | nindent 10 }}
 */}}
 {{- define "fmi-cronjobs.renderVolumes" -}}
 {{- $mounts := (default (list) .mounts) -}}
+{{- $pvcMounts := (default (list) .pvcMounts) -}}
 {{- $tmp := (default (dict) .tmp) -}}
 {{- $renderTmp := and $tmp (hasKey $tmp "enabled") ($tmp.enabled) -}}
 
-{{- if or (gt (len $mounts) 0) $renderTmp }}
+{{- if or (gt (len $mounts) 0) (gt (len $pvcMounts) 0) $renderTmp }}
 volumes:
 {{- if $renderTmp }}
   - name: tmp
@@ -77,17 +78,23 @@ volumes:
       readOnly: true
       {{- end }}
 {{- end }}
+{{- range $mount := $pvcMounts }}
+  - name: {{ required "pvcMount.name is required" $mount.name }}
+    persistentVolumeClaim:
+      claimName: {{ required "pvcMount.claimName is required" $mount.claimName }}
+{{- end }}
 {{- end }}
 {{- end }}
 
 {{/*
-Render all volumeMounts: NFS mounts + optional tmp emptyDir
+Render all volumeMounts: NFS mounts + PVC mounts + optional tmp emptyDir
 */}}
 {{- define "fmi-cronjobs.renderVolumeMounts" -}}
 {{- $mounts := (default (list) .mounts) -}}
+{{- $pvcMounts := (default (list) .pvcMounts) -}}
 {{- $tmp := (default (dict) .tmp) -}}
 
-{{- if or (gt (len $mounts) 0) (and $tmp $tmp.enabled) }}
+{{- if or (gt (len $mounts) 0) (gt (len $pvcMounts) 0) (and $tmp $tmp.enabled) }}
 volumeMounts:
 {{- range $mount := $mounts }}
   - name: {{ required "mount.name is required" $mount.name }}
@@ -101,7 +108,18 @@ volumeMounts:
     readOnly: true
     {{- end }}
 {{- end }}
-
+{{- range $mount := $pvcMounts }}
+  - name: {{ required "pvcMount.name is required" $mount.name }}
+    mountPath: {{ required "pvcMount.mountPath is required" $mount.mountPath }}
+    {{- if $mount.subPath }}
+    subPath: {{ $mount.subPath }}
+    {{- end }}
+    {{- if hasKey $mount "readOnly" }}
+    readOnly: {{ $mount.readOnly }}
+    {{- else }}
+    readOnly: false
+    {{- end }}
+{{- end }}
 {{- if and $tmp $tmp.enabled }}
   - name: tmp
     mountPath: {{ required "tmp.mountPath is required when tmp.enabled=true" $tmp.mountPath }}

--- a/charts/fmi-cronjobs/templates/cronjobs.yaml
+++ b/charts/fmi-cronjobs/templates/cronjobs.yaml
@@ -57,7 +57,7 @@ spec:
               {{- end }}
               {{ include "fmi-cronjobs.renderEnv" $job.env | nindent 14 }}
               {{ include "fmi-cronjobs.renderResources" (dict "job" $job "defaults" $defaults) | nindent 14 }}
-              {{ include "fmi-cronjobs.renderVolumeMounts" (dict "mounts" ($job.mounts | default (list)) "tmp" ($job.tmp | default (dict))) | nindent 14 }}
-          {{ include "fmi-cronjobs.renderVolumes" (dict "mounts" ($job.mounts | default (list)) "tmp" ($job.tmp | default (dict))) | nindent 10 }}
+              {{ include "fmi-cronjobs.renderVolumeMounts" (dict "mounts" ($job.mounts | default (list)) "pvcMounts" ($job.pvcMounts | default (list)) "tmp" ($job.tmp | default (dict))) | nindent 14 }}
+          {{ include "fmi-cronjobs.renderVolumes" (dict "mounts" ($job.mounts | default (list)) "pvcMounts" ($job.pvcMounts | default (list)) "tmp" ($job.tmp | default (dict))) | nindent 10 }}
 {{- end -}}
 {{- end -}}

--- a/charts/fmi-cronjobs/templates/pvcs.yaml
+++ b/charts/fmi-cronjobs/templates/pvcs.yaml
@@ -1,0 +1,26 @@
+{{- range $pvc := .Values.pvcs }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ required "pvcs[].name is required" $pvc.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Chart.Name }}
+    app.kubernetes.io/component: pvc
+  {{- if $pvc.annotations }}
+  annotations:
+    {{- toYaml $pvc.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml (required "pvcs[].accessModes is required" $pvc.accessModes) | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ required "pvcs[].size is required" $pvc.size }}
+  storageClassName: {{ default "ocs-storagecluster-cephfs" $pvc.storageClassName }}
+  {{- if $pvc.volumeName }}
+  volumeName: {{ $pvc.volumeName }}
+  {{- end }}
+{{- end }}

--- a/charts/fmi-cronjobs/values.yaml
+++ b/charts/fmi-cronjobs/values.yaml
@@ -11,6 +11,19 @@ defaults: {}
 #   failedJobsHistoryLimit: 3
 #   resourcePreset: minimal
 
+
+# List of PersistentVolumeClaims to be created by the chart. These can be used by all of the defined jobs.
+# Fields not defined as optional are required
+pvcs: []
+# pvcs:
+#   - name: my-cronjob-pvc # name your pvc with the jobname intend to use the claim for clarity
+#     accessModes: [ReadWriteMany] # Access mode must be compatible with the storage class and the intended usage (e.g., ReadWriteMany for shared access)
+#     size: 1Gi
+#     storageClassName: ocs-storagecluster-cephfs   # optional, defaults to ocs-storagecluster-cephfs
+#     annotations: {}                # optional
+#     volumeName: ""                 # optional
+
+
 # List of CronJob definitions. See README.md for the full configuration reference.
 #
 # Minimal example:
@@ -21,4 +34,15 @@ defaults: {}
 #       image:
 #         repository: quay.io/myorg/my-image
 #         tag: 1.0.0
+
+# Mount an existing or chart-managed PVC to job:
+#   jobs:
+#     - name: my-job
+#       ...
+#       pvcMounts:
+#         - name: my-cronjob-data
+#           claimName: my-cronjob-pvc
+#           mountPath: /data
+#           readOnly: false
+#           subPath: ""        # optional
 jobs: []


### PR DESCRIPTION
 # Description
  Add PVC support to fmi-cronjobs chart

  Extends the `fmi-cronjobs` chart to allow defining PersistentVolumeClaims and mounting them into CronJob pods. This enables cronjobs to share persistent storage across runs or between jobs.

  ## Features

  - New top-level `pvcs` list in `values.yaml` to create PVCs
  - New `pvcMounts` field per job to mount any existing PVC into a container
  - Supports `subPath`, `readOnly`, and `storageClassName` overrides (defaults to `ocs-storagecluster-cephfs`)
  - Updated `_helpers.tpl` (`renderVolumes` / `renderVolumeMounts`) to handle PVC-backed volumes alongside existing NFS and emptyDir mounts
  
  ## Docs
  - Updated README with configuration reference and examples

  ## Build

  - Bumped chart version to `0.2.0`